### PR TITLE
Add some utility methods to support revert mods and download mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,19 +131,11 @@ For periodic maintenance, I recommend using a filter: `docker builder prune --fi
 
 - Added `--download-mod` flag to `launch-cluster.sh` to download GitHub PRs as mods.
 - Added `--list-mods` flag to `launch-cluster.sh` to list available mods.
-- Added `--revert-mod` flag to `launch-cluster.sh` to revert a previously applied mod.
-- Updated `--apply-mod` to explicitly call the `apply` method in the mod's `run.sh` script.
 
 Example: Downloading a PR as a mod
 
 ```bash
 ./launch-cluster.sh --download-mod https://github.com/vllm-project/vllm/pull/31386
-```
-
-Example: Reverting a mod
-
-```bash
-./launch-cluster.sh --revert-mod ./mods/fix-Salyut1-GLM-4.7-NVFP4
 ```
 
 Example: Listing available mods
@@ -646,7 +638,7 @@ To create your own mod:
 
 1. Create a new directory in the `mods/` folder
 2. Add your patch files (`.patch`) or other assets as necessary (optional).
-3. Create a `run.sh` script to apply the patch. This script should handle `apply`, `revert` and `description` actions.
+3. Create a `run.sh` script to apply the patch. This script should handle `apply` and `description` actions.
 4. Reference your mod using the `--apply-mod path/to/your/mod` flag
 
 ### Downloading Mods from GitHub PRs
@@ -660,7 +652,7 @@ You can automatically download a pull request from the vLLM repository and conve
 This will:
 1.  Download the PR patch.
 2.  Create a mod directory (e.g., `mods/pr-31386`).
-3.  Generate a `run.sh` script to apply/revert the patch.
+3.  Generate a `run.sh` script to apply the patch.
 4.  Fetch the PR title for the description.
 
 You can then apply it:

--- a/mods/fix-Salyut1-GLM-4.7-NVFP4/run.sh
+++ b/mods/fix-Salyut1-GLM-4.7-NVFP4/run.sh
@@ -9,20 +9,11 @@ apply() {
     patch -p1 -d / < "$PATCH_FILE"
 }
 
-revert() {
-    echo "Reverting patch..."
-    patch -R -p1 -d / < "$PATCH_FILE"
-}
-
 description() {
     echo "Fixes Salyut1/GLM-4.7-NVFP4 incompatibility by patching glm4_moe parser"
 }
 
-if [ "$1" == "revert" ]; then
-    revert
-elif [ "$1" == "apply" ]; then
-    apply
-elif [ "$1" == "description" ]; then
+if [ "$1" == "description" ]; then
     description
 else
     apply


### PR DESCRIPTION
This PR introduces a comprehensive system for managing modifications (patches) to the vLLM container environment. It adds functionality to apply, revert, list, and automatically download mods from GitHub Pull Requests, streamlining the process of testing fixes and custom configurations.

Key Changes: 

> Mod Management in launch-cluster.sh:

1. Added --revert-mod <path> to undo applied patches.
2. Added --list-mods to display available mods with dynamically wrapped descriptions.
3. Added --download-mod <PR_URL> to automatically fetch a GitHub PR, sanitize the diff for the container environment, and generate a compatible run.sh script.

> Standardized Mod Interface:

Refactored run.sh structure to support apply(), revert(), and description() functions.
Updates to launch-cluster.sh to call these specific functions rather than just executing the script.

> Path Convenience:

Automatic resolution of paths in the [mods](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) directory (e.g., --apply-mod my-mod now resolves to mods/my-mod).

> Documentation:

Updated README.md with a new "Mod Management" section detailing usage examples for creating, listing, and downloading mods.

> Support sequential operations and mixed actions in a single command.

I changed MOD_PATHS to MOD_QUEUE_PATHS (and introduced MOD_QUEUE_ACTIONS and MOD_QUEUE_TYPES) to support sequential operations and mixed actions in a single command.

Previously, if we just had a list of paths, we wouldn't know if the user wanted to apply or revert them, or in what order.

By using parallel arrays:

MOD_QUEUE_PATHS: Stores the path to the mod.
MOD_QUEUE_ACTIONS: Stores "apply" or "revert".
MOD_QUEUE_TYPES: Stores "dir" or "zip".