### PR TITLE
Fix rsync failure if destination dir doesn't exist

### DIFF
--- a/hf-download.sh
+++ b/hf-download.sh
@@ -42,7 +42,7 @@ copy_model_to_host() {
     local host_copy_start host_copy_end host_copy_time
     host_copy_start=$(date +%s)
     
-    if rsync -av --progress "$model_dir" "${SSH_USER}@${host}:$HUB_PATH/"; then
+    if rsync -av --mkpath --progress "$model_dir" "${SSH_USER}@${host}:$HUB_PATH/"; then
         host_copy_end=$(date +%s)
         host_copy_time=$((host_copy_end - host_copy_start))
         printf "Copy to %s completed in %02d:%02d:%02d\n" "$host" $((host_copy_time/3600)) $((host_copy_time%3600/60)) $((host_copy_time%60))


### PR DESCRIPTION
Add `--mkpath` arg to model copy rsync command in order to create the destination `.cache/huggingface/hub` folder if it doesn't already exist.