### PR TITLE
Fix shell quoting for exec command arguments

### DIFF
--- a/launch-cluster.sh
+++ b/launch-cluster.sh
@@ -115,7 +115,7 @@ while [[ "$#" -gt 0 ]]; do
             fi
             ACTION="exec"
             shift
-            COMMAND_TO_RUN="$@"
+            COMMAND_TO_RUN=$(printf "%q " "$@")
             break
             ;;
         *) 

--- a/run-recipe.py
+++ b/run-recipe.py
@@ -86,6 +86,7 @@ RELATED FILES:
 import argparse
 import os
 import subprocess
+import shlex
 import sys
 import tempfile
 from pathlib import Path
@@ -473,7 +474,7 @@ def generate_launch_script(recipe: dict[str, Any], overrides: dict[str, Any], is
     # Append extra args if provided (after --)
     if extra_args:
         # Join extra args and append to command
-        extra_args_str = ' '.join(extra_args)
+        extra_args_str = ' '.join(shlex.quote(a) for a in extra_args)
         command = command.rstrip()
         # Handle multi-line commands with backslash continuations
         if command.endswith('\\'):


### PR DESCRIPTION
## Summary
- Fix improper quoting of exec command arguments in `launch-cluster.sh` and `run-recipe.py`
- Arguments containing special characters (e.g. JSON strings) were passed unquoted, causing breakage for commands like:
  ```
  --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":2}'
  ```
- Uses `printf %q` in `launch-cluster.sh` and `shlex.quote()` in `run-recipe.py` to properly escape arguments

## Tested
- Verified exec command with JSON argument containing special characters works correctly