### PR TITLE
Add fix-opaque-base mod for Qwen3.5 recipe

### DIFF
--- a/mods/fix-opaque-base/run.sh
+++ b/mods/fix-opaque-base/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+patch -p1 -d /usr/local/lib/python3.12/dist-packages < vllm-opaque-base.patch

--- a/mods/fix-opaque-base/vllm-opaque-base.patch
+++ b/mods/fix-opaque-base/vllm-opaque-base.patch
@@ -1,0 +1,15 @@
+--- a/vllm/utils/torch_utils.py
++++ b/vllm/utils/torch_utils.py
+@@ -744,7 +744,11 @@
+ HAS_OPAQUE_TYPE = is_torch_equal_or_newer("2.11.0.dev")
+ 
+ if HAS_OPAQUE_TYPE:
+-    from torch._opaque_base import OpaqueBase
++    try:
++        from torch._opaque_base import OpaqueBase
++    except ImportError:
++        HAS_OPAQUE_TYPE = False
++        OpaqueBase = object  # type: ignore[misc, assignment]
+ else:
+     OpaqueBase = object  # type: ignore[misc, assignment]
+ 

--- a/recipes/qwen3.5-122b-int4-autoround.yaml
+++ b/recipes/qwen3.5-122b-int4-autoround.yaml
@@ -18,6 +18,7 @@ build_args:
 
 # Mod required to fix ROPE syntax error
 mods:
+  - mods/fix-opaque-base
   - mods/fix-qwen3.5-autoround
 
 # Default settings (can be overridden via CLI)


### PR DESCRIPTION
## Summary
- Adds `mods/fix-opaque-base` to patch vllm `torch_utils.py` for missing `OpaqueBase` import
- Adds the mod to the `qwen3.5-122b-int4-autoround` recipe

## Tested
- Verified Qwen3.5-122B recipe builds and runs with the mod applied