### PR TITLE
fix: skip empty lines in wheel download read loop

### DIFF
--- a/build-and-copy.sh
+++ b/build-and-copy.sh
@@ -198,6 +198,7 @@ if downloads:
     local URL NAME TMP_WHL
     local DOWNLOADED=()
     while IFS=' ' read -r URL NAME; do
+        [ -z "$URL" ] && continue
         echo "Downloading $NAME..."
         TMP_WHL=$(mktemp "$WHEELS_DIR/${NAME}.XXXXXX")
         if curl -L --progress-bar --connect-timeout 30 "$URL" -o "$TMP_WHL"; then


### PR DESCRIPTION
This PR addresses #86 

This line seems to cause trouble:
https://github.com/eugr/spark-vllm-docker/blob/9dc09bd04b6420a3b3c155c05bf2542dbb0dbdd7/build-and-copy.sh#L179

Proposed fix: Add a guard to skip empty lines (e.g. trailing newlines) in the while-read loop to prevent try_download_wheels from breaking on unexpected blank input.

