### PR TITLE
Add Qwen3.5-397B INT4-AutoRound recipe

### DIFF
--- a/recipes/qwen3.5-397b-int4-autoround.yaml
+++ b/recipes/qwen3.5-397b-int4-autoround.yaml
@@ -1,0 +1,51 @@
+# Recipe: Qwen3.5-397B-A17B-INT4-Autoround
+# Qwen3.5-397B MoE model in Intel INT4-Autoround quantization
+
+recipe_version: "1"
+name: Qwen3.5-397B-INT4-Autoround
+description: vLLM serving Qwen3.5-397B-INT4-Autoround
+
+# HuggingFace model to download (optional, for --download-model)
+model: Intel/Qwen3.5-397B-A17B-int4-AutoRound
+
+# Container image to use
+container: vllm-node-tf5
+
+build_args:
+  - --tf5
+
+# Can only be run in a cluster
+cluster_only: true
+
+# Mod required to fix ROPE syntax error
+mods:
+  - mods/fix-qwen3.5-autoround
+
+# Default settings (can be overridden via CLI)
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 2
+  gpu_memory_utilization: 0.7
+  max_model_len: 262144
+  max_num_batched_tokens: 8192
+
+# Environment variables
+env:
+  VLLM_MARLIN_USE_ATOMIC_ADD: 1
+
+# The vLLM serve command template
+command: |
+  vllm serve Intel/Qwen3.5-397B-A17B-int4-AutoRound \
+    --max-model-len {max_model_len} \
+    --gpu-memory-utilization {gpu_memory_utilization} \
+    --port {port} \
+    --host {host} \
+    --enable-prefix-caching \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_coder \
+    --reasoning-parser qwen3 \
+    --max-num-batched-tokens {max_num_batched_tokens} \
+    --trust-remote-code \
+    -tp {tensor_parallel} \
+    --distributed-executor-backend ray


### PR DESCRIPTION
## Summary
- New recipe for Intel/Qwen3.5-397B-A17B-int4-AutoRound (MoE, ~17B active params)
- Uses `vllm-node-tf5` container with transformers 5.x
- Cluster-only (TP=2), uses `fix-qwen3.5-autoround` mod
- Includes `--reasoning-parser qwen3` and `--tool-call-parser qwen3_coder`
- Does not use `fastsafetensors` due to duplicate weight keys in the model files

## Test plan
- [x] Tested serving on 2-node Spark cluster with TP=2
- [x] Verified chat completions work correctly (with and without thinking mode)