### PR TITLE
Fix: Correctly insert multi-node args after model name in --no-ray mode

### DIFF
--- a/launch-cluster.sh
+++ b/launch-cluster.sh
@@ -559,7 +559,10 @@ make_node_script() {
 
     local tmp; tmp=$(mktemp /tmp/vllm_node_script_XXXXXX.sh)
     grep -v -- '--distributed-executor-backend' "$script_path" > "$tmp"
-    sed -i "$ s/$/ $extra/" "$tmp"
+    # Insert args after model name, handling multi-line (with \) and single-line commands
+    # Also handles model paths with spaces
+    sed -i "s|^\(vllm serve .*\) \\\\$|\1 $extra \\\\|" "$tmp"
+    sed -i "s|^\(vllm serve .[^\\\\]*\)$|\1 $extra|" "$tmp"
     chmod +x "$tmp"
     echo "$tmp"
 }
@@ -761,6 +764,8 @@ exec_no_ray_cluster() {
         else
             local clean
             clean=$(echo "$base_cmd" | sed 's/--distributed-executor-backend[[:space:]]*[^[:space:]]*//')
+            # For direct commands, append multi-node args at the end
+            # This works for both single-line and multi-line commands
             worker_cmd="$clean --nnodes $total_nodes --node-rank $rank --master-addr $HEAD_IP --headless"
         fi
         echo "Launching worker (rank $rank) on $worker..."
@@ -776,6 +781,7 @@ exec_no_ray_cluster() {
     else
         local clean
         clean=$(echo "$base_cmd" | sed 's/--distributed-executor-backend[[:space:]]*[^[:space:]]*//')
+        # For direct commands, append multi-node args at the end
         head_cmd="$clean --nnodes $total_nodes --node-rank 0 --master-addr $HEAD_IP"
     fi
 


### PR DESCRIPTION
## Problem
When using `--no-ray` mode with `--launch-script`, the multi-node arguments were being inserted between `vllm serve` and the model name, causing vLLM to fail with "model should be provided as the first positional argument" error.

## Solution
Fixed the `make_node_script()` function to insert arguments **after** the model name instead of before it.

### Changes
- Fixed sed command in `make_node_script()` to properly insert args after model name
- Added support for model paths with spaces (quoted paths)
- Handles both multi-line commands and single-line commands
- Added clarifying comments to `exec_no_ray_cluster()`

## Testing
Tested successfully with multi-line commands, model paths with spaces, and single-line commands.

## Impact
Enables the `--no-ray` flag to work correctly with `--launch-script` for multi-node vLLM clusters without Ray overhead.