### PR TITLE
Remove run-cluster-node.sh script copy and permission commands from Dockerfile.mxfp4

### DIFF
--- a/Dockerfile.mxfp4
+++ b/Dockerfile.mxfp4
@@ -270,10 +270,6 @@ ENV TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas
 ENV TIKTOKEN_ENCODINGS_BASE=$VLLM_BASE_DIR/tiktoken_encodings
 ENV PATH=$VLLM_BASE_DIR:$PATH
 
-# Copy scripts
-COPY run-cluster-node.sh $VLLM_BASE_DIR/
-RUN chmod +x $VLLM_BASE_DIR/run-cluster-node.sh
-
 # Final extra deps
 RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
     uv pip install ray[default] fastsafetensors nvidia-nvshmem-cu13


### PR DESCRIPTION
--mxfp4 image build was failing as the run-cluster-node.sh was removed.