### PR TITLE
Add mod: fix-mistral-reasoning-effort

### DIFF
--- a/mods/fix-mistral-reasoning-effort/fix.diff
+++ b/mods/fix-mistral-reasoning-effort/fix.diff
@@ -1,0 +1,17 @@
+--- a/vllm/tokenizers/mistral.py
++++ b/vllm/tokenizers/mistral.py
+@@ -432,7 +432,13 @@
+         # NOTE: This is for backward compatibility.
+         # Transformers should be passed arguments it knows.
+         if self.version >= 15:
+-            version_kwargs["reasoning_effort"] = kwargs.get("reasoning_effort")
++            _re = kwargs.get("reasoning_effort")
++            if _re is not None:
++                try:
++                    from mistral_common.protocol.instruct.messages import REASONING_EFFORTS
++                    version_kwargs["reasoning_effort"] = _re
++                except (ImportError, AttributeError):
++                    pass
+ 
+         messages, tools = _prepare_apply_chat_template_tools_and_messages(
+             messages, tools, continue_final_message, add_generation_prompt

--- a/mods/fix-mistral-reasoning-effort/run.sh
+++ b/mods/fix-mistral-reasoning-effort/run.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# Fix: vLLM unconditionally passes reasoning_effort to apply_chat_template,
+# but mistral_common <1.11 doesn't support it, causing 400 on every request.
+# Workaround until PR #37081 lands in a release.
+#
+# Safe to apply on any version: skips if already patched or not applicable.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SITE_PACKAGES=$(python3 -c "import site; print(site.getsitepackages()[0])")
+
+echo "Applying fix-mistral-reasoning-effort patch..."
+if patch --dry-run -p1 -d "$SITE_PACKAGES" < "$SCRIPT_DIR/fix.diff" &>/dev/null; then
+    patch -p1 -d "$SITE_PACKAGES" < "$SCRIPT_DIR/fix.diff"
+    echo "Patch applied successfully."
+else
+    echo "Patch not applicable (already applied or code has changed), skipping."
+fi


### PR DESCRIPTION
## Problem

vLLM 0.17.2rc1 unconditionally passes `reasoning_effort` to `apply_chat_template`, but `mistral_common` <1.11 does not support it, causing a 400 error on every request when using Mistral models.

## Fix

This mod guards the `reasoning_effort` kwarg with a null check and a `try/except` import of `REASONING_EFFORTS` from `mistral_common`, skipping gracefully if the installed version does not support it.

Uses `patch` command as recommended — safe to apply on any vLLM version, skips automatically if already applied or not applicable.

## Usage

```bash
./launch-cluster.sh --apply-mod mods/fix-mistral-reasoning-effort ...
```

Workaround until PR vllm-project/vllm#37081 lands in a vLLM release.