### PR TITLE
feat(recipes): add Nemotron-Cascade-2-30B-A3B serving recipe

### DIFF
--- a/recipes/nemotron-cascade-2-30B-A3B.yaml
+++ b/recipes/nemotron-cascade-2-30B-A3B.yaml
@@ -1,0 +1,55 @@
+description: vLLM serving Nemotron-Cascade-2-30B-A3B on a SINGLE NODE ONLY!
+model: nvidia/Nemotron-Cascade-2-30B-A3B
+container: vllm-node
+mods:
+  - mods/nemotron-nano
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 1
+  gpu_memory_utilization: 0.7
+  max_model_len: 131072
+env:
+  VLLM_USE_FLASHINFER_MOE_FP4: '1'
+  VLLM_FLASHINFER_MOE_BACKEND: throughput
+  HF_TOKEN: "${HF_TOKEN}"
+command: |
+  vllm serve nvidia/Nemotron-Cascade-2-30B-A3B \
+     --max-model-len {max_model_len} \
+     --port {port} --host {host} \
+     --trust-remote-code \
+     --enable-auto-tool-choice  \
+     --tool-call-parser qwen3_coder \
+     --reasoning-parser-plugin nano_v3_reasoning_parser.py \
+     --reasoning-parser nano_v3  \
+     --kv-cache-dtype fp8  \
+     --attention-backend flashinfer  \
+     --load-format fastsafetensors  \
+     --gpu-memory-utilization {gpu_memory_utilization}
+recipe_version: '1'
+name: Nemotron-Cascade-2-30B-A3B
+cluster_only: false
+solo_only: true
+benchmark:
+  framework: llama-benchy
+  args:
+    pp:
+      - 2048
+    tg:
+      - 128
+    depth:
+      - 0
+      - 4096
+      - 8192
+      - 16384
+      - 32768
+      - 65535
+      - 100000
+    enable_prefix_caching: false
+    concurrency:
+      - 1
+      - 2
+      - 5
+      - 10
+    save_result: benchmark_NVIDIA-Nemotron-Cascade-2-30B-A3B.csv
+    format: csv


### PR DESCRIPTION
Single-node vLLM recipe for nvidia/Nemotron-Cascade-2-30B-A3B with:
- FP8 KV-cache, FlashInfer attention + MoE backend
- 128K max context, tool calling (qwen3_coder parser)
- Custom nano_v3 reasoning parser
- llama-benchy benchmark config (pp2048/tg128, depths 0-100K, c1-c10)

### Benchmark Results — Nemotron-Cascade-2-30B-A3B

 
#### Key Performance
- **Prompt processing:** 3,398 t/s (c1 baseline), scales to ~4,069 t/s aggregate at c10
- **Token generation:** ~31 tok/s per request (c1), stable across all context depths
- **Context-prefilled processing:** up to 8,500 t/s at 4K depth
- **Max context:** 100K tokens tested
 
#### Scaling Behavior (d32768)
| Concurrency | Aggregate t/s | Per-req t/s | TG per-req | TTFT |
|:-:|--:|--:|--:|--:|
| 1 | 237 | 237 | 30.2 | 8.6s |
| 10 | 235 | 68 | 4.7 | 48.2s |
 
#### Known Limits
- **TG degrades sharply** at high depth + concurrency (1.7 t/s at d100K, c10)
- **TTFT at d100K c10:** ~166s — likely impractical for interactive use