### PR TITLE
Fix: stabilize Intel/Qwen3.5-397B-A17B-int4-AutoRound loading via fastsafetensors deduplication

### DIFF
--- a/dedup-safetensors.py
+++ b/dedup-safetensors.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+dedup-safetensors.py — Remove duplicate tensor keys from sharded safetensors checkpoints.
+
+Some quantized checkpoints produce shards with overlapping tensor keys.
+fastsafetensors requires globally unique keys and will error with
+"key ...qweight must be unique among files".
+
+IMPORTANT: This script uses "last shard wins" semantics, NOT "index wins".
+Standard PyTorch/HF loaders process shards sequentially (00001 → 00041).
+If the same key appears in both shard 39 and shard 40, shard 40's version
+silently overwrites shard 39's. This is significant because quantization
+boundary bugs (e.g., Intel AutoRound on the 397B) can leave aborted/garbage
+tensors in an earlier shard while the finalized version lands in a later shard.
+The index.json may point to the EARLIER shard (the garbage), so trusting the
+index would delete the correct data. Instead, we keep the last-writer-wins
+version and update the index to match.
+
+Usage:
+    python3 dedup-safetensors.py /models/Qwen3.5-397B-A17B-int4-AutoRound
+    python3 dedup-safetensors.py /models/... --dry-run
+
+Requires: pip install safetensors torch
+"""
+
+import argparse
+import json
+import shutil
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+from safetensors.torch import load_file, save_file
+
+
+def scan_shards(model_dir: Path):
+    """Scan all shards and find which keys exist in which shards."""
+    index_path = model_dir / "model.safetensors.index.json"
+    if not index_path.exists():
+        print(f"ERROR: {index_path} not found.")
+        sys.exit(1)
+
+    with open(index_path) as f:
+        index = json.load(f)
+
+    weight_map = index["weight_map"]
+
+    # Find all shard files (from index + any extras on disk)
+    shard_files = sorted(set(weight_map.values()))
+
+    # Build map: key -> list of shards that contain it (in shard order)
+    key_locations = defaultdict(list)
+
+    for shard_name in shard_files:
+        shard_path = model_dir / shard_name
+        if not shard_path.exists():
+            print(f"  WARN: {shard_name} referenced in index but not found, skipping.")
+            continue
+
+        tensors = load_file(str(shard_path), device="cpu")
+        for key in tensors.keys():
+            key_locations[key].append(shard_name)
+
+    return key_locations, index, shard_files
+
+
+def deduplicate(model_dir: Path, dry_run: bool = False):
+    """Remove duplicate keys using last-shard-wins semantics."""
+    print(f"Model directory: {model_dir}")
+    print(f"Scanning all shards for duplicate keys...\n")
+
+    key_locations, index, shard_files = scan_shards(model_dir)
+
+    # Find keys that appear in multiple shards
+    duplicated_keys = {k: shards for k, shards in key_locations.items() if len(shards) > 1}
+
+    if not duplicated_keys:
+        print("No duplicate keys found. Checkpoint is clean.")
+        return
+
+    # For each duplicated key, the LAST shard wins (matches standard loader behavior)
+    # Remove the key from all earlier shards
+    keys_to_remove = defaultdict(set)  # shard -> keys to remove from it
+    index_updates = {}  # key -> new canonical shard
+
+    for key, shards in duplicated_keys.items():
+        winner = shards[-1]  # last shard wins
+        for loser in shards[:-1]:
+            keys_to_remove[loser].add(key)
+        # Update index to point to the winner
+        if index["weight_map"].get(key) != winner:
+            index_updates[key] = winner
+
+    total_removals = sum(len(keys) for keys in keys_to_remove.values())
+    print(f"Found {len(duplicated_keys)} duplicated key(s) across shards.\n")
+
+    print(f"Resolution (last shard wins):")
+    for shard_name in sorted(keys_to_remove.keys()):
+        keys = keys_to_remove[shard_name]
+        print(f"\n  {shard_name}: remove {len(keys)} key(s)")
+        for key in sorted(keys):
+            winner = duplicated_keys[key][-1]
+            index_ptr = index["weight_map"].get(key, "???")
+            flag = " *** INDEX DISAGREED ***" if index_ptr == shard_name else ""
+            print(f"    - {key}")
+            print(f"      keep in: {winner}  |  index said: {index_ptr}{flag}")
+
+    if index_updates:
+        print(f"\n  Index corrections: {len(index_updates)} key(s) remapped")
+        for key, new_shard in sorted(index_updates.items()):
+            old_shard = index["weight_map"].get(key, "???")
+            print(f"    {key}: {old_shard} -> {new_shard}")
+
+    if dry_run:
+        print(f"\nDry run — no files modified.")
+        return
+
+    print(f"\nDeduplicating...")
+
+    # Rewrite shards that have keys to remove
+    for shard_name in sorted(keys_to_remove.keys()):
+        remove_keys = keys_to_remove[shard_name]
+        shard_path = model_dir / shard_name
+        backup_path = shard_path.with_suffix(".safetensors.bak")
+
+        print(f"  {shard_name}: removing {len(remove_keys)} key(s)...")
+
+        # Load all tensors
+        tensors = load_file(str(shard_path), device="cpu")
+
+        # Back up original
+        shutil.copy2(shard_path, backup_path)
+
+        # Remove duplicate keys (keeping them in the later shard)
+        clean_tensors = {k: v for k, v in tensors.items() if k not in remove_keys}
+
+        # Rewrite shard
+        save_file(clean_tensors, str(shard_path))
+
+        # Verify rewritten file is readable and has correct keys
+        verify = load_file(str(shard_path), device="cpu")
+        if set(verify.keys()) != set(clean_tensors.keys()):
+            print(f"    ERROR: verification failed, restoring backup!")
+            shutil.copy2(backup_path, shard_path)
+            sys.exit(1)
+
+        # Remove backup after successful verify
+        backup_path.unlink()
+        print(f"    OK — verified.")
+
+    # Update index.json to reflect last-shard-wins
+    if index_updates:
+        index_path = model_dir / "model.safetensors.index.json"
+        backup_index = index_path.with_suffix(".json.bak")
+        shutil.copy2(index_path, backup_index)
+
+        for key, new_shard in index_updates.items():
+            index["weight_map"][key] = new_shard
+
+        with open(index_path, "w") as f:
+            json.dump(index, f, indent=2, sort_keys=False)
+            f.write("\n")
+
+        backup_index.unlink()
+        print(f"\n  Updated index.json ({len(index_updates)} key(s) remapped).")
+
+    print(f"\nDone. Removed {total_removals} duplicate(s) from {len(keys_to_remove)} shard(s).")
+    print(f"fastsafetensors should now work with this checkpoint.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Remove duplicate tensor keys from sharded safetensors checkpoints."
+    )
+    parser.add_argument("model_dir", type=Path, help="Path to model directory")
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Scan and report duplicates without modifying files"
+    )
+    args = parser.parse_args()
+
+    if not args.model_dir.is_dir():
+        print(f"ERROR: {args.model_dir} is not a directory.")
+        sys.exit(1)
+
+    deduplicate(args.model_dir, dry_run=args.dry_run)

--- a/mods/fix-fastsafetensors-no-broadcast/apply_fastsafetensors_no_broadcast.py
+++ b/mods/fix-fastsafetensors-no-broadcast/apply_fastsafetensors_no_broadcast.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+Force fastsafetensors to use SingleGroup (independent per-rank loading) instead
+of the TP process group (NCCL broadcast during loading).
+
+On GB10 unified memory (128GB shared CPU/GPU), the NCCL broadcast path in
+fastsafetensors causes OOM: each reading rank temporarily holds
+ALL tensors from a shard (~5GB) before broadcasting half away. With 100GB of
+accumulated weights + 5GB broadcast buffer + OS overhead > 119GB usable.
+
+With SingleGroup, each rank reads ALL shard files independently and extracts
+only its own TP partition. No NCCL during loading. Peak memory = accumulated
+own tensors + single tensor being read (MB, not GB).
+
+After loading, NCCL is used normally for tensor-parallel inference — this patch
+only affects the weight loading phase.
+
+Trade-off: each rank independently reads the full checkpoint from disk (local NVMe
+or networked) instead of receiving its shards via NCCL broadcast. This eliminates
+the massive network memory buffers that crash GB10 Unified Memory architectures.
+"""
+
+import site
+import re
+from pathlib import Path
+
+site_pkgs = Path(site.getsitepackages()[0])
+weight_utils = site_pkgs / "vllm" / "model_executor" / "model_loader" / "weight_utils.py"
+
+if not weight_utils.exists():
+    print(f"  WARN: {weight_utils} not found, skipping.")
+    exit(0)
+
+src = weight_utils.read_text()
+
+# Target: the weight_files_sub_lists construction in fastsafetensors_weights_iterator.
+# Original code (may vary slightly across versions):
+#
+#   weight_files_sub_lists = [
+#       hf_weights_files[i : i + pg.size()]
+#       for i in range(0, len(hf_weights_files), pg.size())
+#   ]
+#
+# We replace pg.size() with 1 in both the slice and the range step, making
+# every file its own sub-list. Each rank processes every sub-list (SingleGroup
+# behavior) regardless of the actual process group.
+
+pattern = re.compile(
+    r"(weight_files_sub_lists\s*=\s*\[\s*\n"
+    r"\s*hf_weights_files\[i\s*:\s*i\s*\+\s*)pg\.size\(\)"
+    r"(\]\s*\n\s*for\s+i\s+in\s+range\(0,\s*len\(hf_weights_files\),\s*)"
+    r"pg\.size\(\)"
+    r"(\)\s*\n\s*\])",
+    re.MULTILINE,
+)
+
+match = pattern.search(src)
+if not match:
+    # Try alternate formatting (single line or different whitespace)
+    alt = re.compile(
+        r"(hf_weights_files\[i\s*:\s*i\s*\+\s*)pg\.size\(\)"
+        r"(.*?range\(0,\s*len\(hf_weights_files\),\s*)"
+        r"pg\.size\(\)",
+        re.DOTALL,
+    )
+    match = alt.search(src)
+    if not match:
+        print("  WARN: Could not find fastsafetensors weight_files_sub_lists pattern, skipping.")
+        exit(0)
+
+# Inject `pg = None` directly before the assignment, and replace pg.size() with 1
+replaced_block = "pg = None\n    " + match.group(0).replace("pg.size()", "1")
+new_src = src[:match.start()] + replaced_block + src[match.end():]
+
+# Scrub remaining pg.size() usages which would now crash as pg is None.
+# Enforce nogds=True (required for GB10) by substituting the boolean check.
+new_src = new_src.replace("pg.size() > 1", "True")
+new_src = new_src.replace("pg.size()", "1")
+
+# Add a comment before the patched line
+comment = "    # GB10: force per-rank independent loading (no NCCL broadcast) for unified memory\n"
+insert_pos = new_src.rfind("\n", 0, new_src.find("pg = None")) + 1
+if new_src[insert_pos:insert_pos + len(comment)] != comment:
+    new_src = new_src[:insert_pos] + comment + new_src[insert_pos:]
+
+if new_src != src:
+    weight_utils.write_text(new_src)
+    print("  Applied fastsafetensors no-broadcast patch (pg=None enforced).")
+else:
+    print("  Already applied or no change needed.")

--- a/mods/fix-fastsafetensors-no-broadcast/run.sh
+++ b/mods/fix-fastsafetensors-no-broadcast/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+python3 apply_fastsafetensors_no_broadcast.py

--- a/recipes/qwen3.5-397b-int4-autoround.yaml
+++ b/recipes/qwen3.5-397b-int4-autoround.yaml
@@ -18,11 +18,23 @@ container: vllm-node-tf5
 build_args:
   - --tf5
 
+# ==============================================================================
+# The official Intel/Qwen3.5-397B-A17B-int4-AutoRound checkpoint has duplicate
+# tensor keys leaked between shard_39 and shard_40.
+# While the default vLLM loader silently overwrites these duplicates, the
+# `fastsafetensors` loader strictly enforces unique keys and will CRASH
+# if not manually fixed.
+#
+# Before running this recipe, sanitize the model files:
+#   python3 dedup-safetensors.py /path/to/models/Intel/Qwen3.5-397B-A17B...
+# ==============================================================================
+
 # Mod required to fix ROPE syntax error
 mods:
   - mods/fix-qwen3.5-autoround
   - mods/fix-qwen3.5-chat-template
   - mods/gpu-mem-util-gb
+  - mods/fix-fastsafetensors-no-broadcast
 
 # Default settings (can be overridden via CLI)
 defaults:
@@ -34,13 +46,14 @@ defaults:
   max_num_batched_tokens: 4176
 
 # Environment variables
-env: 
-  PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True" 
+env:
+  PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"
   VLLM_MARLIN_USE_ATOMIC_ADD: 1
 
 # The vLLM serve command template
 command: |
   vllm serve Intel/Qwen3.5-397B-A17B-int4-AutoRound \
+    --load-format fastsafetensors \
     --max-model-len {max_model_len} \
     --max-num-seqs 2 \
     --kv-cache-dtype fp8 \
@@ -56,5 +69,3 @@ command: |
     --chat-template unsloth.jinja \
     -tp {tensor_parallel} \
     --distributed-executor-backend ray
-
-  


### PR DESCRIPTION
## Summary
Fix for `Intel/Qwen3.5-397B-A17B-int4-AutoRound` checkpoint compatibility with the `fastsafetensors` loader.

## Problem
The official `Intel/Qwen3.5-397B-A17B-int4-AutoRound` checkpoint has duplicate tensor keys leaked between `shard_39` and `shard_40`. While the default vLLM loader silently overwrites these duplicates, the `fastsafetensors` loader strictly enforces unique keys and crashes with: `key ...qweight must be unique among files`

Additionally, on GB10 unified memory machines (128GB shared CPU/GPU RAM), the default NCCL broadcast path in `fastsafetensors` causes hard OOM panics during loading. This is caused by massive temporary network buffers being allocated when Rank 0 attempts to scatter the 5GB chunks across the cluster.

## Solution
Two-part fix:

### 1. Deduplication Utility (`dedup-safetensors.py`)
- Scans sharded safetensors checkpoints for duplicate tensor keys.
- Enforces "last shard wins" semantics (matches standard PyTorch/HF sequential loader behavior) to preserve the most recent quantization pass.
- Updates `model.safetensors.index.json` to reflect the correct, sanitized shard mappings.
- Creates automatic `.bak` backups before modification and verifies integrity post-rewrite.
- Supports `--dry-run` mode for standalone inspection.

**Usage:**
```bash
python3 dedup-safetensors.py /path/to/models/Intel/Qwen3.5-397B-A17B-int4-AutoRound
```

### 2. FastSafeTensors No-Broadcast Mod (`mods/fix-fastsafetensors-no-broadcast/`)
Forces `fastsafetensors` to drop to a `SingleGroup` (independent per-rank loading) instead of using the TP Process Group for NCCL scatter broadcasting.
- **Before:** Rank 0 reads all tensors from a shard (~5GB) and allocates massive NCCL flight buffers in unified memory to broadcast half away → OOM kernel panic.
- **After:** Each rank independently reads the full checkpoint from disk (local NVMe or networked) and quietly keeps its own partition.

### 3. Recipe Update (`recipes/qwen3.5-397b-int4-autoround.yaml`)
- Added `mods/fix-fastsafetensors-no-broadcast` to the automatic mod chain.
- Injected `--load-format fastsafetensors` flag.

## Testing
- Tested on dual-node DGX Spark cluster (GB10 SM121, TP=2).
- Successfully loads full 397B parameters natively with `fastsafetensors` in ~3m.
- 0 OOM crashes during weight loading.

```bash
docker exec -it vllm-head vllm bench serve \
  --backend vllm \
  --model Intel/Qwen3.5-397B-A17B-int4-AutoRound \
  --dataset-name random \
  --random-input-len 512 \
  --random-output-len 128 \
  --num-prompts 500
```

```text
============ Serving Benchmark Result ============
Successful requests:                     500
Failed requests:                         0
Benchmark duration (s):                  1584.69
Total input tokens:                      256000
Total generated tokens:                  64000
Request throughput (req/s):              0.32
Output token throughput (tok/s):         40.39
Peak output token throughput (tok/s):    54.00
Peak concurrent requests:                500.00
Total token throughput (tok/s):          201.93
---------------Time to First Token----------------
Mean TTFT (ms):                          792260.33
Median TTFT (ms):                        792448.99
P99 TTFT (ms):                           1566111.27
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          46.02
Median TPOT (ms):                        46.10
P99 TPOT (ms):                           47.43
---------------Inter-token Latency----------------
Mean ITL (ms):                           46.02
Median ITL (ms):                         42.98
P99 ITL (ms):                            55.54
==================================================
```

## Files Changed
- `dedup-safetensors.py` (new) - Standalone deduplication utility
- `mods/fix-fastsafetensors-no-broadcast/` (new) - Mod to disable network scattering
- `recipes/qwen3.5-397b-int4-autoround.yaml` - Added loader flags and documentation

## Notes
- The deduplication script is purely standalone and generic; it can be pointed at any corrupted HuggingFace safetensor cache.
- The `no-broadcast` mod is specifically engineered to stabilize GB10 unified memory architectures, but provides stable performance ceilings for any memory-constrained edge deployment.
