### PR TITLE
fix: update qwen3.5-autoround patch for new transformers RotaryEmbeddingConfigMixin

### DIFF
--- a/mods/fix-qwen3.5-autoround/transformers.patch
+++ b/mods/fix-qwen3.5-autoround/transformers.patch
@@ -1,11 +1,11 @@
 --- a/transformers/modeling_rope_utils.py
 +++ b/transformers/modeling_rope_utils.py
-@@ -648,7 +648,7 @@
-             ignore_keys_at_rope_validation = (
-                 set() if ignore_keys_at_rope_validation is None else ignore_keys_at_rope_validation
-             )
--            ignore_keys_at_rope_validation = ignore_keys_at_rope_validation | {"partial_rotary_factor"}
-+            ignore_keys_at_rope_validation = set(ignore_keys_at_rope_validation) | {"partial_rotary_factor"}
-
+@@ -646,7 +646,7 @@
+         partial_rotary_factor = kwargs.get("partial_rotary_factor", getattr(self, "partial_rotary_factor", None))
+         if partial_rotary_factor is not None:
+             self.rope_parameters.setdefault("partial_rotary_factor", partial_rotary_factor)
+-            self.ignore_keys_at_rope_validation = self.ignore_keys_at_rope_validation | {"partial_rotary_factor"}
++            self.ignore_keys_at_rope_validation = set(self.ignore_keys_at_rope_validation) | {"partial_rotary_factor"}
+ 
          self.standardize_rope_params()
-         self.validate_rope(ignore_keys=ignore_keys_at_rope_validation)
+         return kwargs


### PR DESCRIPTION
*Problem*
The fix-qwen3.5-autoround mod fails to apply on recent builds:

```
patching file transformers/modeling_rope_utils.py
Hunk #1 FAILED at 648.
1 out of 1 hunk FAILED -- saving rejects to file transformers/modeling_rope_utils.py.rej
```

*Root Cause*
The `transformers` library refactored the RoPE validation logic. The `ignore_keys_at_rope_validation` handling moved from a standalone function (using local variables) into the `RotaryEmbeddingConfigMixin` class, where it's now a class attribute and instance method:

```
python
# Old code (standalone function)
ignore_keys_at_rope_validation = (
    set() if ignore_keys_at_rope_validation is None else ignore_keys_at_rope_validation
)
ignore_keys_at_rope_validation = ignore_keys_at_rope_validation | {"partial_rotary_factor"}
# New code (class-based)
class RotaryEmbeddingConfigMixin:
    ignore_keys_at_rope_validation = set()
    ...
    self.ignore_keys_at_rope_validation = self.ignore_keys_at_rope_validation | {"partial_rotary_factor"}
```

The old patch context no longer matches, causing the hunk to fail.

*Fix*
Updated the patch to target the new class-based code. The underlying fix remains the same — wrapping in `set()` to handle subclasses that may define `ignore_keys_at_rope_validation` as a non-set iterable (e.g. tuple), which would cause a `TypeError `on the `|` operator:

```
diff
-            self.ignore_keys_at_rope_validation = self.ignore_keys_at_rope_validation | {"partial_rotary_factor"}
+            self.ignore_keys_at_rope_validation = set(self.ignore_keys_at_rope_validation) | {"partial_rotary_factor"}
```

*Testing*
Verified the patch applies cleanly against the current container image (`vllm-node-tf5`).