### PR TITLE
Fix FP8 CUTLASS crash on SM12.1 (DGX Spark)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -206,6 +206,11 @@ RUN curl -fsL https://patch-diff.githubusercontent.com/raw/vllm-project/vllm/pul
        fi \
     && rm pr38126.diff
 
+# FIX: enable_sm120_only -> enable_sm120_family for SM12.1 FP8 CUTLASS (saifgithub/vllm-gb10-sm121)
+RUN sed -i "s/enable_sm120_only/enable_sm120_family/g" \
+    csrc/quantization/w8a8/cutlass/c3x/scaled_mm.cuh \
+    csrc/quantization/w8a8/cutlass/c3x/scaled_mm_sm120_fp8_dispatch.cuh
+
 # Final Compilation
 RUN --mount=type=cache,id=ccache,target=/root/.ccache \
     --mount=type=cache,id=uv-cache,target=/root/.cache/uv \


### PR DESCRIPTION
## Summary

- Fixes `"This kernel only supports sm120."` crash when running FP8 models (e.g. Qwen3.5-35B-FP8) on DGX Spark (SM12.1)
- Replaces `enable_sm120_only` with `enable_sm120_family` in two CUTLASS kernel files, allowing SM12.1 (`__CUDA_ARCH__ == 1210`) to pass the architecture guard
- One-line sed applied at build time, before final compilation

**This is a temporary workaround until the upstream fix is merged: [vllm-project/vllm#35568](https://github.com/vllm-project/vllm/pull/35568)**

## Details

vLLM's FP8 CUTLASS kernel wrappers use `enable_sm120_only`, which checks `__CUDA_ARCH__ == 1200` and traps on any other arch. On SM12.1 (GB10, DGX Spark), `__CUDA_ARCH__` is `1210`, triggering `cudaErrorLaunchFailure` on every FP8 GEMM call.

`enable_sm120_family` already exists in the codebase (`>= 1200 && < 1300`) and is used by the blockwise dispatch path. This fix applies it to the two remaining files that still use `enable_sm120_only`.

See: https://github.com/saifgithub/vllm-gb10-sm121

## Rebuild notes

Requires `--rebuild-vllm` since the fix is compiled into the binary. If upgrading from a previous build, clean Docker build cache first:

```
docker builder prune
./build-and-copy.sh --rebuild-vllm [--tf5] [-t vllm-node-tf5]
```

Note: `--tf5` and `-t vllm-node-tf5` are optional — the container name depends on your setup (default is `vllm-node`).

## Test plan

- [x] Verified on DGX Spark with Qwen3.5-35B-A3B-FP8 — model loads and serves without crash
- [x] Confirmed `enable_sm120_family` symbols present in compiled `_C.abi3.so`