### PR TITLE
Daemon Service Mode: Update docker run arguments for restart policy

### DIFF
--- a/launch-cluster.sh
+++ b/launch-cluster.sh
@@ -846,7 +846,14 @@ start_cluster() {
     fi
 
     # Build docker run arguments based on mode
-    local docker_args_common="--gpus all -d --rm --network host --name $CONTAINER_NAME $DOCKER_ARGS $IMAGE_NAME"
+    local docker_restart_args=""
+    if [[ "$DAEMON_MODE" == "true" ]]; then
+        docker_restart_args="--restart unless-stopped"
+    else
+        docker_restart_args="--rm"
+    fi
+    local docker_args_common="--gpus all -d $docker_restart_args --network host --name $CONTAINER_NAME $DOCKER_ARGS $IMAGE_NAME"
+
     local docker_caps_args=""
     local docker_resource_args=""
 


### PR DESCRIPTION
Modify launch_cluster.sh docker run arguments to include restart policy based on daemon mode.

Two minor updates - if user selects daemon (-d) mode:

1. Remove `--rm` to prevent container removal on stop.
2. Add `--restart unless-stopped` to container startup to auto-restart container on reboot or crash.

Tested with **qwen3.5-397b-int4-autoround** recipe on Two DGX Spark setup:

```bash
# Run Cluster - Daemon Mode - Specify IB Addresses - 109G GPU Mem
./run-recipe.sh qwen3.5-397b-int4-autoround.yaml --no-ray -n 169.254.147.5,169.254.161.198 -d --gpu-mem 109
```

Super helpful, project, @eugr ! Thank you for putting this together.