### PR TITLE
fix: make SM121 FP8 patch resilient to upstream changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -204,15 +204,9 @@ RUN if [ -n "$VLLM_PRS" ]; then \
         done; \
     fi
 
-# TEMPORARY PATCH for broken FP8 kernels - https://github.com/vllm-project/vllm/pull/35568
-RUN curl -fsL https://patch-diff.githubusercontent.com/raw/vllm-project/vllm/pull/35568.diff -o pr35568.diff \
-    && if git apply --reverse --check pr35568.diff 2>/dev/null; then \
-         echo "PR 35568 already applied, skipping."; \
-       else \
-         echo "Applying PR 35568..."; \
-         git apply -v pr35568.diff; \
-       fi \
-    && rm pr35568.diff
+# SM121 (DGX Spark) FP8 fixes — equivalent to PR #35568 but context-independent
+COPY patches/sm121-fp8-fix.sh /tmp/sm121-fp8-fix.sh
+RUN /tmp/sm121-fp8-fix.sh && rm /tmp/sm121-fp8-fix.sh
 
 # TEMPORARY PATCH for broken compilation - https://github.com/vllm-project/vllm/pull/38919
 RUN curl -fsL https://patch-diff.githubusercontent.com/raw/vllm-project/vllm/pull/38919.diff -o pr38919.diff \

--- a/patches/sm121-fp8-fix.sh
+++ b/patches/sm121-fp8-fix.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# SM121 (DGX Spark) FP8 fixes — equivalent to PR #35568
+# https://github.com/vllm-project/vllm/pull/35568
+#
+# Uses sed instead of git apply to survive upstream context drift.
+# SM121 shares FP8 MMA capabilities with SM120 but was excluded
+# by exact-match arch guards (== 120, enable_sm120_only, etc.)
+
+set -euo pipefail
+
+# generate_kernels.py (both marlin and moe) — arch check
+sed -i 's/if arch in \[89, 120\]:/if arch == 89 or arch \/\/ 10 == 12:/' \
+    csrc/quantization/marlin/generate_kernels.py \
+    csrc/moe/marlin_moe_wna16/generate_kernels.py
+
+# ops.cu — capability check
+sed -i 's/major_capability \* 10 + minor_capability == 120/major_capability == 12/' \
+    csrc/moe/marlin_moe_wna16/ops.cu
+sed -i 's/Marlin W4A8-FP8 only support SM89 or SM120/Marlin W4A8-FP8 only support SM89 or SM12x/' \
+    csrc/moe/marlin_moe_wna16/ops.cu
+
+# scaled_mm.cuh — enable_sm120_only -> enable_sm120_family
+sed -i 's/enable_sm120_only/enable_sm120_family/g' \
+    csrc/libtorch_stable/quantization/w8a8/cutlass/c3x/scaled_mm.cuh \
+    csrc/libtorch_stable/quantization/w8a8/cutlass/c3x/scaled_mm_sm120_fp8_dispatch.cuh
+
+# marlin_utils.py — is_device_capability(120) -> is_device_capability_family(120)
+sed -i 's/is_device_capability(120)/is_device_capability_family(120)/' \
+    vllm/model_executor/layers/quantization/utils/marlin_utils.py
+sed -i 's/SM89 or SM120 device/SM89 or SM12x device/' \
+    vllm/model_executor/layers/quantization/utils/marlin_utils.py
+
+# Comment updates
+sed -i 's/# only SM89 and SM120 fully support/# SM89 and the SM12x family (SM120 RTX 5090, SM121 DGX Spark GB10)/' \
+    csrc/quantization/marlin/generate_kernels.py \
+    csrc/moe/marlin_moe_wna16/generate_kernels.py
+sed -i 's/# mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32./# fully support mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32./' \
+    csrc/quantization/marlin/generate_kernels.py \
+    csrc/moe/marlin_moe_wna16/generate_kernels.py
+
+echo "Applied SM121 (DGX Spark) FP8 fixes (PR #35568 equivalent)"


### PR DESCRIPTION
## Problem

The SM121 (DGX Spark) FP8 fix ([vllm-project/vllm#35568](https://github.com/vllm-project/vllm/pull/35568)) is applied during build via `curl | git apply`. This breaks whenever upstream commits shift the surrounding context lines — even though the actual target code hasn't changed.

The PR was never merged into vLLM and the `git apply` approach is inherently fragile against a fast-moving codebase like vLLM.

## Fix

Replace the inline `curl | git apply` block with a standalone `patches/sm121-fp8-fix.sh` script that uses `sed` for exact string substitution. This makes the patch:

- **Context-independent** — matches exact strings, not surrounding lines
- **Resilient to upstream churn** — survives line shifts from adjacent PRs
- **Self-healing** — silently no-ops if vLLM eventually merges the fix
- **Cleaner** — keeps the Dockerfile readable (3 lines vs 9)

## What the patch does

Applies the same 8 fixes from PR #35568 across 6 files, changing SM120-only checks to SM12x family checks:

| Pattern | Before | After |
|---|---|---|
| Arch check | `arch in [89, 120]` | `arch == 89 or arch // 10 == 12` |
| Capability check | `== 120` | `== 12` (major) |
| CUTLASS guard | `enable_sm120_only` | `enable_sm120_family` |
| Python check | `is_device_capability(120)` | `is_device_capability_family(120)` |

## Breaking commits identified

Two upstream PRs shifted context around the patched code, causing `git apply` to fail:
- `db5d0719` — [#34664](https://github.com/vllm-project/vllm/pull/34664) "Add MXFP8 to Marlin GEMM/MoE" (Apr 1)
- `ab1a6a43` — [#37221](https://github.com/vllm-project/vllm/pull/37221) "Migrate cutlass/scaled_mm_entry.cu torch stable ABI" (Mar 30)
