### PR TITLE
feat: ignore wheel lock and whl files in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .env
 build-metadata.yaml
+wheels/.*-commit
+wheels/*.whl


### PR DESCRIPTION
Seeing whl and commit files tracked in git when running `./build-and-copy.sh` 