### PR TITLE
Add MiniMax-M2.7-NVFP4 recipe

### DIFF
--- a/recipes/minimax-m2.7-nvfp4.yaml
+++ b/recipes/minimax-m2.7-nvfp4.yaml
@@ -1,0 +1,60 @@
+# Recipe: MiniMax-M2.7-NVFP4
+# MiniMax M2.7 model with NVFP4 (modelopt_fp4) quantization
+# Requires TF5 container build and 2-node cluster (TP=2 via Ray)
+
+recipe_version: "1"
+name: MiniMax-M2.7-NVFP4
+description: vLLM serving MiniMax-M2.7-NVFP4 with CUTLASS kernels and Ray distributed backend
+
+# HuggingFace model to download (optional, for --download-model)
+model: lukealonso/MiniMax-M2.7-NVFP4
+
+# Container image to use (TF5 build for NVFP4 support)
+container: vllm-node-tf5
+build_args:
+  - --tf5
+
+# Requires 2 nodes for TP=2
+cluster_only: true
+
+# No mods required
+mods: []
+
+# Environment variables
+env:
+  VLLM_USE_FLASHINFER_MOE_FP4: "0"
+  VLLM_NVFP4_GEMM_BACKEND: cutlass
+  VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
+  OMP_NUM_THREADS: "8"
+
+# Default settings (can be overridden via CLI)
+defaults:
+  port: 8888
+  host: 0.0.0.0
+  tensor_parallel: 2
+  gpu_memory_utilization: 0.92
+  max_num_seqs: 4
+  max_num_batched_tokens: 8192
+
+# The vLLM serve command template
+command: |
+  vllm serve lukealonso/MiniMax-M2.7-NVFP4 \
+      --port {port} \
+      --host {host} \
+      --max-num-seqs {max_num_seqs} \
+      --max-num-batched-tokens {max_num_batched_tokens} \
+      --gpu-memory-utilization {gpu_memory_utilization} \
+      --mamba_ssm_cache_dtype float32 \
+      --enable-prefix-caching \
+      --enable-auto-tool-choice \
+      --served-model-name MiniMax-M2.7 \
+      --tool-call-parser minimax_m2 \
+      --reasoning-parser minimax_m2_append_think \
+      --kv-cache-dtype fp8 \
+      --quantization modelopt_fp4 \
+      --moe-backend cutlass \
+      --disable-custom-all-reduce \
+      --dtype auto \
+      --trust-remote-code \
+      --tensor-parallel-size {tensor_parallel} \
+      --distributed-executor-backend ray


### PR DESCRIPTION
See [Nvidia forum for details](https://forums.developer.nvidia.com/t/minimax-m2-7-nfvp4-recipe-benchmarks/366324) -- this may not be perfect but it's stable for now.

Verified tool calling in a first few rounds of OpenCode, too.

| model        |            test |              t/s |     peak t/s |         ttfr (ms) |      est_ppt (ms) |     e2e_ttft (ms) |
|:-------------|----------------:|-----------------:|-------------:|------------------:|------------------:|------------------:|
| MiniMax-M2.7 |          pp2048 | 2074.25 ± 223.23 |              |   865.36 ± 108.23 |   863.94 ± 108.23 |   865.42 ± 108.22 |
| MiniMax-M2.7 |           tg128 |     24.30 ± 0.02 | 25.00 ± 0.00 |                   |                   |                   |
| MiniMax-M2.7 |  pp2048 @ d4096 | 2249.52 ± 305.90 |              |  2377.95 ± 302.17 |  2376.52 ± 302.17 |  2378.01 ± 302.18 |
| MiniMax-M2.7 |   tg128 @ d4096 |     23.75 ± 0.08 | 24.33 ± 0.47 |                   |                   |                   |
| MiniMax-M2.7 |  pp2048 @ d8192 | 2146.48 ± 526.28 |              | 4515.71 ± 1247.48 | 4514.29 ± 1247.48 | 4515.80 ± 1247.48 |
| MiniMax-M2.7 |   tg128 @ d8192 |     22.92 ± 0.14 | 24.00 ± 0.82 |                   |                   |                   |
| MiniMax-M2.7 | pp2048 @ d16384 |   2471.71 ± 7.59 |              |   6474.06 ± 67.79 |   6472.63 ± 67.79 |   6474.11 ± 67.78 |
| MiniMax-M2.7 |  tg128 @ d16384 |     21.78 ± 0.41 | 23.00 ± 0.00 |                   |                   |                   |

llama-benchy (0.3.5)
date: 2026-04-12 20:43:17 | latency mode: api