### PR TITLE
Add InstantTensor to runtime dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -341,7 +341,7 @@ ENV PATH=$VLLM_BASE_DIR:$PATH
 
 # Final extra deps
 RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
-    uv pip install ray[default] fastsafetensors
+    uv pip install ray[default] fastsafetensors instanttensor
 
 # Fix NCCL
 RUN rm /usr/local/lib/python3.12/dist-packages/nvidia/nccl/lib/libnccl.so.2 && \


### PR DESCRIPTION
Adds instanttensor as available load format (addresses https://github.com/eugr/spark-vllm-docker/issues/188)

Makes `--load-format instanttensor` available.