### PR TITLE
Add a recipe option to use local vetted code rather than trust-remote-code.

### DIFF
--- a/recipes/minimax-m2.5-awq-local.yaml
+++ b/recipes/minimax-m2.5-awq-local.yaml
@@ -1,0 +1,46 @@
+# Recipe: MiniMax-M2.5-AWQ-Local
+# Like minimax-m2.5-awq but uses locally vetted code instead of --trust-remote-code.
+# The vetted_local_code field points to a sibling repo (vetted-vllm-code) which installs
+# a vetted MiniMaxM2Config class as a vLLM plugin so transformers can load the model config
+# without network access or trust-remote-code.
+#
+# SETUP:
+#   1. Download the model first (only needed once):
+#      ./run-recipe.py minimax-m2.5-awq --download-model
+#   2. Review the vetted code in ../vetted-vllm-code/minimax-m2.5-awq/ if desired
+#   3. Run this recipe:
+#      ./run-recipe.py minimax-m2.5-awq-local
+
+recipe_version: "1"
+name: MiniMax-M2.5-AWQ-Local
+description: vLLM serving MiniMax-M2.5-AWQ using local vetted code (no trust-remote-code, offline HF)
+
+model: cyankiwi/MiniMax-M2.5-AWQ-4bit
+container: vllm-node
+cluster_only: true
+solo_only: false
+
+vetted_local_code: ../vetted-vllm-code/minimax-m2.5-awq
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 2
+  gpu_memory_utilization: 0.7
+  max_model_len: 128000
+
+env:
+  HF_HUB_OFFLINE: "1"
+
+command: |
+  vllm serve cyankiwi/MiniMax-M2.5-AWQ-4bit \
+      --port {port} \
+      --host {host} \
+      --gpu-memory-utilization {gpu_memory_utilization} \
+      -tp {tensor_parallel} \
+      --distributed-executor-backend ray \
+      --max-model-len {max_model_len} \
+      --load-format fastsafetensors \
+      --enable-auto-tool-choice \
+      --tool-call-parser minimax_m2 \
+      --reasoning-parser minimax_m2

--- a/recipes/minimax-m2.7-nvfp4-local.yaml
+++ b/recipes/minimax-m2.7-nvfp4-local.yaml
@@ -1,0 +1,48 @@
+# Recipe: MiniMax-M2.7-NVFP4-Local
+# Serves lukealonso/MiniMax-M2.7-NVFP4 using locally vetted code instead of
+# --trust-remote-code. Reuses the same vetted MiniMaxM2Config plugin as the
+# M2.5 recipe — the config class is identical between the two models.
+#
+# SETUP:
+#   1. Download the model first (only needed once):
+#      ./run-recipe.py minimax-m2.7-nvfp4-local --download-model
+#   2. Review the vetted code in ../vetted-vllm-code/minimax-m2.5-awq/ if desired
+#   3. Run this recipe:
+#      ./run-recipe.py minimax-m2.7-nvfp4-local
+
+recipe_version: "1"
+name: MiniMax-M2.7-NVFP4-Local
+description: vLLM serving MiniMax-M2.7-NVFP4 using local vetted code (no trust-remote-code, offline HF)
+
+model: lukealonso/MiniMax-M2.7-NVFP4
+container: vllm-node
+cluster_only: true
+solo_only: false
+
+vetted_local_code: ../vetted-vllm-code/minimax-m2.5-awq
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 2
+  gpu_memory_utilization: 0.7
+  max_model_len: 196600
+
+env:
+  VLLM_FLASHINFER_ALLREDUCE_BACKEND: trtllm
+  HF_HUB_OFFLINE: "1"
+
+command: |
+  vllm serve lukealonso/MiniMax-M2.7-NVFP4 \
+      --kv-cache-dtype fp8 \
+      --moe-backend cutlass \
+      --gpu-memory-utilization {gpu_memory_utilization} \
+      --max-model-len {max_model_len} \
+      --port {port} \
+      --host {host} \
+      --enable-auto-tool-choice \
+      --load-format fastsafetensors \
+      --tool-call-parser minimax_m2 \
+      --reasoning-parser minimax_m2 \
+      -tp {tensor_parallel} \
+      --distributed-executor-backend ray

--- a/recipes/nemotron-3-super-nvfp4-local.yaml
+++ b/recipes/nemotron-3-super-nvfp4-local.yaml
@@ -1,0 +1,55 @@
+# Recipe: Nemotron-3-Super-NVFP4-Local
+# Like nemotron-3-super-nvfp4 but uses locally vetted code instead of --trust-remote-code.
+# The vetted_remote_code field points to a sibling repo (vetted-vllm-code) which installs
+# a vetted NemotronHConfig class as a vLLM plugin so transformers can load the model config
+# without network access or trust-remote-code.
+#
+# SETUP:
+#   1. Download the model first (only needed once):
+#      ./run-recipe.py nemotron-3-super-nvfp4 --download-model
+#   2. Review the vetted code in ../vetted-vllm-code/nemotron-super/ if desired
+#   3. Run this recipe:
+#      ./run-recipe.py nemotron-3-super-nvfp4-local
+
+recipe_version: "1"
+name: Nemotron-3-Super-NVFP4-Local
+description: vLLM serving Nemotron-3-Super-120B using local vetted code (no trust-remote-code, offline HF)
+
+model: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4
+container: vllm-node
+cluster_only: false
+solo_only: false
+
+vetted_local_code: ../vetted-vllm-code/nemotron-super
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 2
+  gpu_memory_utilization: 0.7
+  max_model_len: 262144
+  max_num_seqs: 10
+
+env:
+  VLLM_FLASHINFER_ALLREDUCE_BACKEND: trtllm
+  VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
+  HF_HUB_OFFLINE: "1"
+
+command: |
+  vllm serve nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 \
+  --kv-cache-dtype fp8 \
+  --moe-backend cutlass \
+  --gpu-memory-utilization {gpu_memory_utilization} \
+  --max-model-len {max_model_len} \
+  --max-num-seqs {max_num_seqs} \
+  --enable-prefix-caching \
+  --host {host} \
+  --port {port} \
+  --enable-auto-tool-choice \
+  --load-format fastsafetensors \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser nemotron_v3 \
+  --mamba_ssm_cache_dtype float32 \
+  --tensor-parallel-size {tensor_parallel} \
+  --attention-backend TRITON_ATTN \
+  --distributed-executor-backend ray

--- a/run-recipe.py
+++ b/run-recipe.py
@@ -85,10 +85,12 @@ RELATED FILES:
 
 import argparse
 import os
-import subprocess
 import shlex
+import shutil
+import subprocess
 import sys
 import tempfile
+import urllib.parse
 from pathlib import Path
 from typing import Any
 
@@ -130,6 +132,11 @@ def load_recipe(recipe_path: Path) -> dict[str, Any]:
         description (str, optional): Brief description shown in --list
         model (str, optional): HuggingFace model ID for --setup downloads
         mods (list[str], optional): List of mod directories to apply (e.g., 'mods/fix-glm')
+        vetted_local_code (str, optional): Local path or git URL pointing to a directory of
+            vetted model code that will be applied as a mod, replacing --trust-remote-code.
+            - Local path: resolved relative to SCRIPT_DIR. E.g. '../vetted-vllm-code/nemotron-super'
+            - Git URL: cloned to a temp dir each run. Use '#subpath' to specify a subdirectory
+              within the repo. E.g. 'https://github.com/user/vetted-vllm-code.git#nemotron-super'
         defaults (dict, optional): Default values for command placeholders
         env (dict, optional): Environment variables to export before running
         build_args (list[str], optional): Extra args for build-and-copy.sh (e.g., ['-f', 'Dockerfile.mxfp4'])
@@ -179,6 +186,7 @@ def load_recipe(recipe_path: Path) -> dict[str, Any]:
     recipe.setdefault("description", "")
     recipe.setdefault("model", None)
     recipe.setdefault("mods", [])
+    recipe.setdefault("vetted_local_code", None)
     recipe.setdefault("defaults", {})
     recipe.setdefault("env", {})
     recipe.setdefault("cluster_only", False)
@@ -196,6 +204,58 @@ def load_recipe(recipe_path: Path) -> dict[str, Any]:
         print("Some features may not work correctly. Consider updating run-recipe.py.")
 
     return recipe
+
+
+def resolve_vetted_local_code(value: str, cleanup_dirs: list) -> Path:
+    """
+    Resolve a vetted_local_code value to a local directory path.
+
+    Supports two forms:
+      - Local path (absolute or relative to SCRIPT_DIR):
+          ../vetted-vllm-code/nemotron-super
+      - Git URL with optional '#subpath' fragment:
+          https://github.com/user/vetted-vllm-code.git#nemotron-super
+
+    For git URLs, the repo is cloned into a temporary directory which is
+    added to cleanup_dirs so it is removed after the launch command runs.
+
+    Args:
+        value: The vetted_local_code string from the recipe.
+        cleanup_dirs: List to append temp dirs that should be deleted on exit.
+
+    Returns:
+        Resolved Path to the mod directory.
+    """
+    parsed = urllib.parse.urlparse(value)
+    is_git_url = parsed.scheme in ("http", "https", "ssh", "git") or value.startswith("git@")
+
+    if is_git_url:
+        # Split off '#subpath' fragment if present
+        if "#" in value:
+            url, subpath = value.split("#", 1)
+        else:
+            url, subpath = value, ""
+
+        tmpdir = tempfile.mkdtemp(prefix="spark-vllm-vetted-")
+        cleanup_dirs.append(tmpdir)
+        print(f"Cloning vetted_local_code from {url} ...")
+        result = subprocess.run(
+            ["git", "clone", "--depth=1", url, tmpdir],
+            capture_output=True, text=True
+        )
+        if result.returncode != 0:
+            print(f"Error: Failed to clone {url}")
+            print(result.stderr)
+            sys.exit(1)
+
+        mod_path = Path(tmpdir) / subpath if subpath else Path(tmpdir)
+        if not mod_path.exists():
+            print(f"Error: subpath '{subpath}' not found in cloned repo {url}")
+            sys.exit(1)
+        return mod_path
+    else:
+        # Local path — resolve relative to SCRIPT_DIR
+        return (SCRIPT_DIR / value).resolve()
 
 
 def list_recipes() -> None:
@@ -1203,6 +1263,8 @@ Examples:
         cmd_parts = ["   ./launch-cluster.sh", "-t", container]
         for mod in recipe.get("mods", []):
             cmd_parts.extend(["--apply-mod", mod])
+        if recipe.get("vetted_local_code"):
+            cmd_parts.extend(["--apply-mod", recipe["vetted_local_code"]])
         if args.solo:
             cmd_parts.append("--solo")
         elif not is_cluster:
@@ -1252,6 +1314,7 @@ Examples:
         f.write(script_content)
         temp_script = f.name
 
+    vetted_cleanup_dirs: list = []
     try:
         os.chmod(temp_script, 0o755)
 
@@ -1264,6 +1327,13 @@ Examples:
             if not mod_path.exists():
                 print(f"Warning: Mod path not found: {mod_path}")
             cmd.extend(["--apply-mod", str(mod_path)])
+
+        # Add vetted_local_code as a mod (alternative to --trust-remote-code)
+        if recipe.get("vetted_local_code"):
+            vetted_path = resolve_vetted_local_code(recipe["vetted_local_code"], vetted_cleanup_dirs)
+            if not vetted_path.exists():
+                print(f"Warning: vetted_local_code path not found: {vetted_path}")
+            cmd.extend(["--apply-mod", str(vetted_path)])
 
         # Add launch options
         if args.solo:
@@ -1337,6 +1407,12 @@ Examples:
             os.unlink(temp_script)
         except OSError:
             pass
+        # Cleanup any temp dirs created by resolve_vetted_local_code (git clones)
+        for tmpdir in vetted_cleanup_dirs:
+            try:
+                shutil.rmtree(tmpdir)
+            except OSError:
+                pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Using this repo to run models on a pair of sparks that I use for work. For security reasons, I would like to not run models with the -trust-remote-code option and make sure I have inspected the code that is being 'trusted' before I run it in my work environment. To this end, I added an option into the recipe that lets you do that. Might be useful for some others trying to use sparks in their work environment.