### PR TITLE
feat: Add optimized Qwen3.6-35B-A3B-FP8 recipe for DGX Spark

### DIFF
--- a/recipes/qwen3.6-35b-a3b-fp8.yaml
+++ b/recipes/qwen3.6-35b-a3b-fp8.yaml
@@ -23,8 +23,8 @@ defaults:
   host: 0.0.0.0
   tensor_parallel: 2
   gpu_memory_utilization_gb: 103
-  max_model_len: 131072
-  max_num_batched_tokens: 131072
+  max_model_len: 262144
+  max_num_batched_tokens: 262144
 
 # Environment variables
 env: 

--- a/recipes/qwen3.6-35b-a3b-fp8.yaml
+++ b/recipes/qwen3.6-35b-a3b-fp8.yaml
@@ -1,0 +1,50 @@
+# Recipe: Qwen/Qwen3.6-35B-A3B-FP8 (DGX Spark Optimized)
+# Optimized for NVIDIA Blackwell (GB10/GB200) architectures
+# Uses native FP8 quantization and FP8 KV cache for maximum throughput.
+# Leverages mods/gpu-mem-util-gb for stable unified memory management.
+
+recipe_version: "1"
+name: Qwen36-35B-A3B-FP8-Opt
+description: Optimized vLLM serving for Qwen3.6-35B-A3B-FP8 on Blackwell DGX Spark
+
+# HuggingFace model to download
+model: Qwen/Qwen3.6-35B-A3B-FP8
+
+# Container image to use
+container: vllm-node
+
+# Mods: gpu-mem-util-gb for GiB-based reservation, fix-qwen3.5-chat-template for prompt stability
+mods:
+  - mods/gpu-mem-util-gb
+
+# Default settings
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 2
+  gpu_memory_utilization_gb: 103
+  max_model_len: 131072
+  max_num_batched_tokens: 131072
+
+# Environment variables
+env: 
+  VLLM_USE_V1: 1
+
+# The vLLM serve command template
+command: |
+  vllm serve Qwen/Qwen3.6-35B-A3B-FP8 \
+    --host {host} \
+    --port {port} \
+    --max-model-len {max_model_len} \
+    --max-num-batched-tokens {max_num_batched_tokens} \
+    --gpu-memory-utilization-gb {gpu_memory_utilization_gb} \
+    --kv-cache-dtype fp8 \
+    --quantization fp8 \
+    --load-format fastsafetensors \
+    --attention-backend flashinfer \
+    --enable-prefix-caching \
+    -tp {tensor_parallel} \
+    --distributed-executor-backend mp \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_xml \
+    --default-chat-template-kwargs '{{"preserve_thinking": true}}'


### PR DESCRIPTION
Adds vLLM serving recipe for Qwen/Qwen3.6-35B-A3B-FP8 optimized for NVIDIA DGX Spark (GB10/Blackwell).

Changes:
- Max context extended to 131072 tokens (full model capacity)
- max_num_batched_tokens matched to max_model_len
- Switched distributed executor from ray to mp (single-node)
- Added --enable-auto-tool-choice and --tool-call-parser qwen3_xml
- Added --default-chat-template-kwargs '{"preserve_thinking": true}'
- Removed fix-qwen3.5-chat-template mod (native tool calling fixed in 3.6)