### PR TITLE
VLLM_FLOAT32_MATMUL_PRECISION=high for `--mamba_ssm_cache_dtype float32`

### DIFF
--- a/recipes/nemotron-3-super-nvfp4.yaml
+++ b/recipes/nemotron-3-super-nvfp4.yaml
@@ -15,6 +15,7 @@ solo_only: false
 env:
   VLLM_FLASHINFER_ALLREDUCE_BACKEND: trtllm
   VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+  VLLM_FLOAT32_MATMUL_PRECISION: high
 
 container: vllm-node
 defaults:


### PR DESCRIPTION
```(EngineCore pid=94) /usr/local/lib/python3.12/dist-packages/torch/_inductor/compile_fx.py:321: UserWarning: TensorFloat32 tensor cores for float32 matrix multiplication available but not enabled. Consider setting `torch.set_float32_matmul_precision('high')` for better performance.```

**The Explanation (from Gemini)**

You are getting this warning specifically because of a smart flag you included in your launch command: `--mamba_ssm_cache_dtype float32`

Because Nemotron 3 Super relies heavily on Mamba-2 architecture, those Mamba blocks need to accumulate their hidden states in float32 to remain mathematically stable over a 1-million-token context.

When PyTorch compiles the model and sees all this float32 math, it looks at your Grace Blackwell chip and essentially says: "Hey, this GPU has dedicated TensorFloat32 (TF32) cores that can do this math much faster than standard cores, but I'm keeping them turned off by default just to be safe."

TF32 is an NVIDIA math mode that provides the mathematical range of float32 but processes at the speed of float16. For LLM inference, turning it on is a massive free performance upgrade with zero noticeable loss in output quality.

**The Fix (from Gemini)**

Since you are running vLLM directly from the command line, you can't easily inject the Python code the warning suggests (torch.set_float32_matmul_precision('high')).

Instead, vLLM recently added an environment variable specifically to pass this command down to PyTorch. You just need to add one more export to your stack.

Add this line right below your other environment variables before starting the server:

`export VLLM_FLOAT32_MATMUL_PRECISION="high"`

**My Observation**

tok/sec generation is improved.