### PR TITLE
Add GB10 MoE config install mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,21 @@ For periodic maintenance, I recommend using a filter: `docker builder prune --fi
 
 ## CHANGELOG
 
+### 2026-04-22
+
+#### GB10-tuned MoE config for Qwen3.6-35B-A3B-FP8
+
+Added a new mod `mods/install-gb10-moe-config` that installs a tuned fused MoE kernel config for `Qwen/Qwen3.6-35B-A3B-FP8` on `NVIDIA GB10` systems.
+
+This avoids the default Triton fallback (`Using default MoE config. Performance might be sub-optimal!`) for the tuned shape (`E=256`, `N=512`, `dtype=fp8_w8a8`, `block_shape=[128,128]`) and improved throughput by about 30% during local testing on GB10 hardware.
+
+To use it, add the mod when launching:
+
+```bash
+./launch-cluster.sh --solo --apply-mod mods/install-gb10-moe-config \
+  exec vllm serve Qwen/Qwen3.6-35B-A3B-FP8 ...
+```
+
 ### 2026-04-14
 
 Added `--load-format instanttensor` support to vLLM - thanks @SeraphimSerapis. 
@@ -1356,6 +1371,7 @@ The vLLM Docker setup supports applying custom mods and patches to address speci
 The repository includes several pre-configured mods in the `mods/` directory:
 
 - **fix-Salyut1-GLM-4.7-NVFP4/**: Contains patches glm4moe parser to work with fused QKV quantization scheme for Salyut1/GLM-4.7-NVFP4 quant of the newly released GLM 4.7 model.
+- **install-gb10-moe-config/**: Installs a tuned fused MoE kernel config for `Qwen/Qwen3.6-35B-A3B-FP8` on `NVIDIA GB10`, avoiding the generic fallback config and improving throughput.
 
 Each mod directory typically contains:
 - Patch files (`.patch`) for code modifications and/or other assets.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ For periodic maintenance, I recommend using a filter: `docker builder prune --fi
 
 Added a new mod `mods/install-gb10-moe-config` that installs a tuned fused MoE kernel config for `Qwen/Qwen3.6-35B-A3B-FP8` on `NVIDIA GB10` systems.
 
-This avoids the default Triton fallback (`Using default MoE config. Performance might be sub-optimal!`) for the tuned shape (`E=256`, `N=512`, `dtype=fp8_w8a8`, `block_shape=[128,128]`) and improved throughput by about 30% during local testing on GB10 hardware.
+This avoids the default Triton fallback (`Using default MoE config. Performance might be sub-optimal!`) for the tuned shape (`E=256`, `N=512`, `dtype=fp8_w8a8`, `block_shape=[128,128]`) and improved throughput by more than 20% during local testing on GB10 hardware.
 
 To use it, add the mod when launching:
 

--- a/mods/install-gb10-moe-config/E=256,N=512,device_name=NVIDIA_GB10,dtype=fp8_w8a8,block_shape=[128,128].json
+++ b/mods/install-gb10-moe-config/E=256,N=512,device_name=NVIDIA_GB10,dtype=fp8_w8a8,block_shape=[128,128].json
@@ -1,0 +1,99 @@
+{
+    "triton_version": "3.6.0",
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "4": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "24": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "48": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "96": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "256": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 8,
+        "num_stages": 2
+    }
+}

--- a/mods/install-gb10-moe-config/run.sh
+++ b/mods/install-gb10-moe-config/run.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Install the GB10 tuned MoE kernel config into vLLM's configs directory.
+#
+# Generated 2026-04-21 via vLLM's benchmarks/kernels/benchmark_moe.py on GB10
+# hardware for Qwen/Qwen3.6-35B-A3B-FP8 (E=256, N_half=512, hidden=2048,
+# topk=8, dtype=fp8_w8a8, block_shape=[128,128]). Covers batch sizes
+# [1, 2, 4, 8, 16, 24, 32, 48, 64, 96, 128, 256].
+#
+# Without this, vLLM falls back to a generic Triton MoE kernel and prints
+# "Using default MoE config. Performance might be sub-optimal!", which was
+# about 30% slower on this hardware during local testing.
+set -e
+
+MOD_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONFIGS_DIR=/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/configs
+CONFIG_NAME='E=256,N=512,device_name=NVIDIA_GB10,dtype=fp8_w8a8,block_shape=[128,128].json'
+SOURCE_CONFIG="$MOD_DIR/$CONFIG_NAME"
+TARGET_CONFIG="$CONFIGS_DIR/$CONFIG_NAME"
+
+if [[ ! -f "$SOURCE_CONFIG" ]]; then
+  echo "Missing tuned MoE config: $SOURCE_CONFIG" >&2
+  exit 1
+fi
+
+mkdir -p "$CONFIGS_DIR"
+install -m 0644 "$SOURCE_CONFIG" "$TARGET_CONFIG"
+echo "=====> Installed tuned MoE kernel config for Qwen3.6-35B-A3B-FP8 on GB10"

--- a/mods/install-gb10-moe-config/run.sh
+++ b/mods/install-gb10-moe-config/run.sh
@@ -8,7 +8,7 @@
 #
 # Without this, vLLM falls back to a generic Triton MoE kernel and prints
 # "Using default MoE config. Performance might be sub-optimal!", which was
-# about 30% slower on this hardware during local testing.
+# more than 20% slower on this hardware during local testing.
 set -e
 
 MOD_DIR="$(cd "$(dirname "$0")" && pwd)"


### PR DESCRIPTION
## Summary

- add `mods/install-gb10-moe-config`
- install a tuned fused MoE kernel config for `Qwen/Qwen3.6-35B-A3B-FP8` on `NVIDIA GB10`
- document the mod in the changelog and in the README mods list

## Why

On GB10, vLLM can fall back to the default Triton MoE config for this shape and print:

`Using default MoE config. Performance might be sub-optimal!`

This mod installs a benchmarked config for:

- `E=256`
- `N=512`
- `dtype=fp8_w8a8`
- `block_shape=[128,128]`

The config was generated on 2026-04-21 via `benchmarks/kernels/benchmark_moe.py` for `Qwen/Qwen3.6-35B-A3B-FP8` on GB10 hardware.

In local testing on GB10, this avoided the fallback and improved throughput by more than 20%.

## Usage

```bash
./launch-cluster.sh --apply-mod mods/install-gb10-moe-config ...
```

Or in a recipe YAML:

```yaml
mods:
  - mods/install-gb10-moe-config
```

## Notes

This PR keeps the mod narrow and explicit for one verified config rather than trying to generalize it prematurely.

## Validation

- `bash -n mods/install-gb10-moe-config/run.sh`
- verified mod asset is installed from the mod directory into vLLM's fused MoE configs path
- updated README changelog and mods documentation
