### PR TITLE
Update gpu-mem-util-gb: patch with new vLLM default value

### DIFF
--- a/mods/gpu-mem-util-gb/gpu_mem.patch
+++ b/mods/gpu-mem-util-gb/gpu_mem.patch
@@ -82,7 +82,7 @@ index 5909b3043..c2607df6a 100644
 @@ -234,6 +239,7 @@ class LLM:
          chat_template: Path | str | None = None,
          seed: int = 0,
-         gpu_memory_utilization: float = 0.9,
+         gpu_memory_utilization: float = 0.92,
 +        gpu_memory_utilization_gb: float | None = None,
          cpu_offload_gb: float = 0,
          offload_group_size: int = 0,


### PR DESCRIPTION
## Summary
- https://github.com/vllm-project/vllm/pull/38284 changed the default value of `gpu_memory_utilization` in https://github.com/vllm-project/vllm/blob/21792520e727676e4d4e8bd24a8fe29da4dab152/vllm/entrypoints/llm.py#L231 from 0.9 to 0.92. This change caused downstream patches (`gpu_mem.patch`) that referenced the previous default as context to fail to apply on newer versions of vLLM, resulting in patch application errors during.

## Test plan
- [x] Built the container with `./build-and-copy.sh`
- [x] Ran `qwen3.5-35b-a3b-fp8` recipe — model loads and serves