### PR TITLE
Add recipe for Mistral-Small-4-119B-2603-NVFP4

### DIFF
--- a/mods/fix-mistral-small-4-119b-2603-nvfp4/run.sh
+++ b/mods/fix-mistral-small-4-119b-2603-nvfp4/run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+cd /usr/local/lib/python3.12/dist-packages
+echo "Applying vllm-project/vllm#41119"
+if curl -fsL https://patch-diff.githubusercontent.com/raw/vllm-project/vllm/pull/41119.diff | git apply --exclude="tests/*"; then
+  echo "- PR vllm-project/vllm#41119 applied successfully"
+else
+  echo "- PR vllm-project/vllm#41119 can't be applied, skipping"
+fi

--- a/recipes/mistral-small-4-119b-2603-nvfp4.yaml
+++ b/recipes/mistral-small-4-119b-2603-nvfp4.yaml
@@ -8,9 +8,8 @@ description: vLLM serving Mistral-Small-4-119B-2603-NVFP4
 # HuggingFace model to download (optional, for --download-model)
 model: mistralai/Mistral-Small-4-119B-2603-NVFP4
 
-# Only cluster is supported
-cluster_only: false
-solo_only: false
+# Only solo now
+solo_only: true
 
 # Container image to use
 container: vllm-node-tf5

--- a/recipes/mistral-small-4-119b-2603-nvfp4.yaml
+++ b/recipes/mistral-small-4-119b-2603-nvfp4.yaml
@@ -1,0 +1,50 @@
+# Recipe: Mistral-Small-4-119B-2603-NVFP4
+# Mistral-Small-4-119B-2603 model with NVFP4 quantization support
+
+recipe_version: "1"
+name: Mistral-Small-4-119B-2603-NVFP4
+description: vLLM serving Mistral-Small-4-119B-2603-NVFP4
+
+# HuggingFace model to download (optional, for --download-model)
+model: mistralai/Mistral-Small-4-119B-2603-NVFP4
+
+# Only cluster is supported
+cluster_only: false
+solo_only: false
+
+# Container image to use
+container: vllm-node-tf5
+
+build_args:
+  - --tf5
+
+# Mods
+mods:
+  - mods/fix-mistral-small-4-119b-2603-nvfp4
+
+# Default settings (can be overridden via CLI)
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 1
+  gpu_memory_utilization: 0.8
+  max_model_len: 262144
+  max_num_batched_tokens: 16384
+
+# Environment variables
+env: {}
+
+# The vLLM serve command template
+# see: https://huggingface.co/mistralai/Mistral-Small-4-119B-2603-NVFP4#serve-the-model
+command: |
+  vllm serve mistralai/Mistral-Small-4-119B-2603-NVFP4 \
+    --max-model-len {max_model_len} \
+    --gpu-memory-utilization {gpu_memory_utilization} \
+    --port {port} \
+    --host {host} \
+    --attention-backend TRITON_MLA \
+    --tool-call-parser mistral \
+    --enable-auto-tool-choice \
+    --reasoning-parser mistral \
+    --max-num-batched-tokens {max_num_batched_tokens}
+


### PR DESCRIPTION
## Summary

closes #117, #180, #215

Adds a vLLM serving recipe for [mistralai/Mistral-Small-4-119B-2603-NVFP4](https://huggingface.co/mistralai/Mistral-Small-4-119B-2603-NVFP4).

Most issues previously discussed in the [NVIDIA Developer Forums thread](https://forums.developer.nvidia.com/t/running-mistral-small-4-119b-nvfp4-on-nvidia-dgx-spark-gb10/363863) have been resolved upstream in vLLM.

One outstanding issue ([vllm-project/vllm#40260](https://github.com/vllm-project/vllm/issues/40260)) is addressed by applying [vllm-project/vllm#41119](https://github.com/vllm-project/vllm/pull/41119) as a mod until it lands in a release.

## Changes

- Add recipe `recipes/mistral-small-4-119b-2603-nvfp4.yaml`
  - vLLM parameters follow [Mistral's official serving recommendation](https://huggingface.co/mistralai/Mistral-Small-4-119B-2603-NVFP4#serve-the-model)
- Add mod `mods/fix-mistral-small-4-119b-2603-nvfp4/run.sh`
  - Applies upstream PR vllm-project/vllm#41119 at runtime as a patch

Reasoning has been verified to work with the following setup:

```bash
./run-recipe.sh --setup mistral-small-4-119b-2603-nvfp4.yaml -- \
  --override-generation-config '{"temperature": 0.7}' \
  --default-chat-template-kwargs '{"reasoning_effort": "high"}'
```
