### PR TITLE
YAML syntax check: 'container' key was duplicated.

### DIFF
--- a/recipes/nemotron-3-super-nvfp4.yaml
+++ b/recipes/nemotron-3-super-nvfp4.yaml
@@ -16,7 +16,6 @@ env:
   VLLM_FLASHINFER_ALLREDUCE_BACKEND: trtllm
   VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
 
-container: vllm-node
 defaults:
   port: 8000
   host: 0.0.0.0


### PR DESCRIPTION
Was testing recipes/nemotron-3-super-nvfp4.yaml - and upon opening it in my vim, the yaml language server spotted a small typo: the key 'container' was duplicated. Might as well fix it :-)