### PR TITLE
Use upstream git SHA as CACHEBUST instead of $(date +%s)

### DIFF
--- a/build-and-copy.sh
+++ b/build-and-copy.sh
@@ -76,6 +76,23 @@ EOF
     echo "Generated build-metadata.yaml"
 }
 
+# Resolve a stable cache-bust value from upstream git ref.
+# Falls back to timestamp (current behavior) on network / resolution failure,
+# so the script remains usable offline.
+#
+# Usage: resolve_cachebust <repo_url> <ref>
+resolve_cachebust() {
+    local repo_url="$1"
+    local ref="$2"
+    local sha
+    sha=$(git ls-remote "$repo_url" "$ref" 2>/dev/null | head -n1 | cut -f1)
+    if [ -n "$sha" ]; then
+        echo "$sha"
+    else
+        echo "$(date +%s)"
+    fi
+}
+
 add_copy_hosts() {
     local token part
     for token in "$@"; do
@@ -542,7 +559,7 @@ if [ "$NO_BUILD" = false ]; then
                 "--build-arg" "FLASHINFER_REF=$FLASHINFER_REF")
 
             if [ "$REBUILD_FLASHINFER" = true ]; then
-                FI_CMD+=("--build-arg" "CACHEBUST_FLASHINFER=$(date +%s)")
+                FI_CMD+=("--build-arg" "CACHEBUST_FLASHINFER=$(resolve_cachebust https://github.com/flashinfer-ai/flashinfer.git "$FLASHINFER_REF")")
             fi
 
             if [ -n "$FLASHINFER_PRS" ]; then
@@ -609,7 +626,7 @@ if [ "$NO_BUILD" = false ]; then
                 "--build-arg" "VLLM_REF=$VLLM_REF")
 
             if [ "$REBUILD_VLLM" = true ]; then
-                VLLM_CMD+=("--build-arg" "CACHEBUST_VLLM=$(date +%s)")
+                VLLM_CMD+=("--build-arg" "CACHEBUST_VLLM=$(resolve_cachebust https://github.com/vllm-project/vllm.git "$VLLM_REF")")
             fi
 
             if [ -n "$VLLM_PRS" ]; then


### PR DESCRIPTION
## Problem

`CACHEBUST_VLLM` and `CACHEBUST_FLASHINFER` are currently set from `$(date +%s)` on every invocation:

```bash
# build-and-copy.sh
FI_CMD+=("--build-arg" "CACHEBUST_FLASHINFER=$(date +%s)")
# ...
VLLM_CMD+=("--build-arg" "CACHEBUST_VLLM=$(date +%s)")
```

This guarantees freshness (upstream `vllm` / `flashinfer` source is always re-fetched), but it has a side-effect: the buildx cache hash for the wheel-build steps **always misses**, even when nothing has changed upstream. Every `./build-and-copy.sh --rebuild-vllm` is a full ~2-hour vLLM source compile on DGX Spark / GB10, rather than the cache-hit incremental rebuild it could be.

## Fix

Resolve the cache-bust value from the upstream commit SHA instead:

```bash
resolve_cachebust() {
    local repo_url=\"\$1\"
    local ref=\"\$2\"
    local sha
    sha=\$(git ls-remote \"\$repo_url\" \"\$ref\" 2>/dev/null | head -n1 | cut -f1)
    if [ -n \"\$sha\" ]; then
        echo \"\$sha\"
    else
        echo \"\$(date +%s)\"
    fi
}
```

Behavior:

| Upstream state | Before | After |
|---|---|---|
| Unchanged since last build | Full rebuild (~2h) | Step cache-hit (seconds) |
| Has new commits | Full rebuild (~2h) | Full rebuild (~2h) — same as before |
| `git ls-remote` unreachable | n/a | Falls back to `\$(date +%s)` — same as before |

The same approach applies symmetrically to both `CACHEBUST_FLASHINFER` (line 545) and `CACHEBUST_VLLM` (line 612).

## Validation

Tested on dual-DGX-Spark (GB10, SM 12.1):

```
$ resolve_cachebust https://github.com/vllm-project/vllm.git main
6ff7405b81317932cf2e97c7e18dcbae4db7542c
$ resolve_cachebust https://github.com/vllm-project/vllm.git main
6ff7405b81317932cf2e97c7e18dcbae4db7542c
$ resolve_cachebust https://github.com/flashinfer-ai/flashinfer.git main
9d282787d412218aaf6193259598c0487b4926a8
$ resolve_cachebust https://github.com/does-not-exist/nope.git main
1778607085     # graceful fallback to timestamp
```

Two consecutive runs return the same SHA when upstream is unchanged; an invalid URL falls back to a timestamp cleanly.

## Compatibility

- No new dependencies (`git ls-remote` is already required for the git clone steps in the Dockerfile)
- Respects existing `--vllm-ref` / `--flashinfer-ref` overrides (passed through as the `ref` argument)
- Offline / air-gapped builds keep working via the `date +%s` fallback