### PR TITLE
Make vLLM and FlashInfer repo URLs configurable via build args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,7 @@ ARG FLASHINFER_CUDA_ARCH_LIST="12.1a"
 ENV FLASHINFER_CUDA_ARCH_LIST=${FLASHINFER_CUDA_ARCH_LIST}
 WORKDIR $VLLM_BASE_DIR
 ARG FLASHINFER_REF=main
+ARG FLASHINFER_REPO=https://github.com/flashinfer-ai/flashinfer.git
 
 # --- CACHE BUSTER ---
 # Change this argument to force a re-download of FlashInfer
@@ -100,7 +101,7 @@ RUN --mount=type=cache,id=repo-cache,target=/repo-cache \
     cd /repo-cache && \
     if [ ! -d "flashinfer" ]; then \
         echo "Cache miss: Cloning FlashInfer from scratch..." && \
-        git clone --recursive https://github.com/flashinfer-ai/flashinfer.git; \
+        git clone --recursive ${FLASHINFER_REPO}; \
         if [ "$FLASHINFER_REF" != "main" ]; then \
             cd flashinfer && \
             git checkout ${FLASHINFER_REF}; \
@@ -108,6 +109,7 @@ RUN --mount=type=cache,id=repo-cache,target=/repo-cache \
     else \
         echo "Cache hit: Fetching flashinfer updates..." && \
         cd flashinfer && \
+        git remote set-url origin ${FLASHINFER_REPO} 2>/dev/null || true; \
         git fetch origin && \
         git fetch origin --tags --force && \
         (git checkout --detach origin/${FLASHINFER_REF} 2>/dev/null || git checkout ${FLASHINFER_REF}) && \
@@ -181,13 +183,14 @@ ARG CACHEBUST_VLLM=1
 
 # Git reference (branch, tag, or SHA) to checkout
 ARG VLLM_REF=main
+ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 
 # Smart Git Clone (Fetch changes instead of full re-clone)
 RUN --mount=type=cache,id=repo-cache,target=/repo-cache \
     cd /repo-cache && \
     if [ ! -d "vllm" ]; then \
         echo "Cache miss: Cloning vLLM from scratch..." && \
-        git clone --recursive https://github.com/vllm-project/vllm.git; \
+        git clone --recursive ${VLLM_REPO}; \
         if [ "$VLLM_REF" != "main" ]; then \
             cd vllm && \
             git checkout ${VLLM_REF}; \
@@ -195,6 +198,7 @@ RUN --mount=type=cache,id=repo-cache,target=/repo-cache \
     else \
         echo "Cache hit: Fetching updates..." && \
         cd vllm && \
+        git remote set-url origin ${VLLM_REPO} 2>/dev/null || true; \
         git fetch origin && \
         git fetch origin --tags --force && \
         (git checkout --detach origin/${VLLM_REF} 2>/dev/null || git checkout ${VLLM_REF}) && \

--- a/Dockerfile.mxfp4
+++ b/Dockerfile.mxfp4
@@ -109,6 +109,7 @@ RUN --mount=type=cache,id=git-flashinfer,target=/git-cache/flashinfer \
         echo "=== Using cached FlashInfer repo ===" && \
         cp -a /git-cache/flashinfer /workspace/flashinfer && \
         cd /workspace/flashinfer && \
+        git remote set-url origin ${FLASHINFER_REPO} 2>/dev/null || true; \
         git fetch origin && git fetch origin --tags; \
     else \
         echo "=== Cloning FlashInfer (first build) ===" && \
@@ -129,6 +130,7 @@ RUN --mount=type=cache,id=git-cutlass,target=/git-cache/cutlass \
         echo "=== Using cached CUTLASS repo ===" && \
         cp -a /git-cache/cutlass 3rdparty/cutlass && \
         cd 3rdparty/cutlass && \
+        git remote set-url origin ${CUTLASS_REPO} 2>/dev/null || true; \
         git fetch origin && git fetch origin --tags; \
     else \
         echo "=== Cloning CUTLASS (first build) ===" && \
@@ -183,6 +185,7 @@ RUN --mount=type=cache,id=repo-cache,target=/repo-cache \
     else \
         echo "Cache hit: Fetching updates..." && \
         cd vllm-mxfp4 && \
+        git remote set-url origin ${VLLM_REPO} 2>/dev/null || true; \
         git fetch origin && \
         git fetch origin --tags && \
         (git checkout --detach origin/${VLLM_SHA} 2>/dev/null || git checkout ${VLLM_SHA}) && \

--- a/build-and-copy.sh
+++ b/build-and-copy.sh
@@ -17,6 +17,8 @@ VLLM_REF="main"
 VLLM_REF_SET=false
 FLASHINFER_REF="main"
 FLASHINFER_REF_SET=false
+VLLM_REPO="https://github.com/vllm-project/vllm.git"
+FLASHINFER_REPO="https://github.com/flashinfer-ai/flashinfer.git"
 TMP_IMAGE=""
 PARALLEL_COPY=false
 EXP_MXFP4=false
@@ -275,6 +277,8 @@ usage() {
     echo "  --rebuild-vllm                : Force rebuild of vLLM wheels (ignore cached wheels)"
     echo "  --vllm-ref <ref>              : vLLM commit SHA, branch or tag (default: 'main')"
     echo "  --flashinfer-ref <ref>        : FlashInfer commit SHA, branch or tag (default: 'main')"
+    echo "  --vllm-repo <url>             : vLLM repository URL (default: 'https://github.com/vllm-project/vllm.git')"
+    echo "  --flashinfer-repo <url>       : FlashInfer repository URL (default: 'https://github.com/flashinfer-ai/flashinfer.git')"
     echo "  -c, --copy-to <hosts>         : Host(s) to copy the image to. Accepts comma or space-delimited lists."
     echo "      --copy-to-host            : Alias for --copy-to (backwards compatibility)."
     echo "      --copy-parallel           : Copy to all hosts in parallel instead of serially."
@@ -304,6 +308,8 @@ while [[ "$#" -gt 0 ]]; do
         --rebuild-vllm) REBUILD_VLLM=true ;;
         --vllm-ref) VLLM_REF="$2"; VLLM_REF_SET=true; shift ;;
         --flashinfer-ref) FLASHINFER_REF="$2"; FLASHINFER_REF_SET=true; shift ;;
+        --vllm-repo) VLLM_REPO="$2"; shift ;;
+        --flashinfer-repo) FLASHINFER_REPO="$2"; shift ;;
         -c|--copy-to|--copy-to-host|--copy-to-hosts)
             COPY_TO_FLAG=true
             shift
@@ -492,7 +498,7 @@ if [ "$NO_BUILD" = false ]; then
         generate_build_metadata Dockerfile.mxfp4 "unknown" "$MXFP4_VLLM_SHA" "$MXFP4_FLASHINFER_SHA" \
             "mxfp4-pinned" "false" "true" ""
 
-        CMD=("docker" "build" "-t" "$IMAGE_TAG" "${COMMON_BUILD_FLAGS[@]}" "-f" "Dockerfile.mxfp4" ".")
+        CMD=("docker" "build" "-t" "$IMAGE_TAG" "${COMMON_BUILD_FLAGS[@]}" "--build-arg" "VLLM_REPO=$VLLM_REPO" "--build-arg" "FLASHINFER_REPO=$FLASHINFER_REPO" "-f" "Dockerfile.mxfp4" ".")
         echo "Building image with command: ${CMD[*]}"
         BUILD_START=$(date +%s)
         "${CMD[@]}"
@@ -539,7 +545,8 @@ if [ "$NO_BUILD" = false ]; then
                 "--target" "flashinfer-export"
                 "--output" "type=local,dest=./wheels"
                 "${COMMON_BUILD_FLAGS[@]}"
-                "--build-arg" "FLASHINFER_REF=$FLASHINFER_REF")
+                "--build-arg" "FLASHINFER_REF=$FLASHINFER_REF"
+                "--build-arg" "FLASHINFER_REPO=$FLASHINFER_REPO")
 
             if [ "$REBUILD_FLASHINFER" = true ]; then
                 FI_CMD+=("--build-arg" "CACHEBUST_FLASHINFER=$(date +%s)")
@@ -606,7 +613,8 @@ if [ "$NO_BUILD" = false ]; then
                 "--target" "vllm-export"
                 "--output" "type=local,dest=./wheels"
                 "${COMMON_BUILD_FLAGS[@]}"
-                "--build-arg" "VLLM_REF=$VLLM_REF")
+                "--build-arg" "VLLM_REF=$VLLM_REF"
+                "--build-arg" "VLLM_REPO=$VLLM_REPO")
 
             if [ "$REBUILD_VLLM" = true ]; then
                 VLLM_CMD+=("--build-arg" "CACHEBUST_VLLM=$(date +%s)")


### PR DESCRIPTION
Add VLLM_REPO and FLASHINFER_REPO build args to Dockerfile and build-and-copy.sh so alternative forks can be used. Also add git remote set-url in cache-hit paths to ensure the correct remote is fetched when the repo URL changes between builds.