### PR TITLE
Add MiMo V2.5 NVFP4 DGX Spark recipe and mod fixes

### DIFF
--- a/docs/mimo-v25-nvfp4-dgx-spark.md
+++ b/docs/mimo-v25-nvfp4-dgx-spark.md
@@ -1,0 +1,109 @@
+# MiMo-V2.5-NVFP4 on 2× DGX Spark / GB10
+
+This document accompanies `recipes/mimo-v2.5-nvfp4.yaml` and the runtime mods:
+
+- `mods/fix-mimo-v2-vllm`
+- `mods/fix-modelopt-mixed-mxfp8`
+
+The recipe targets [`lukealonso/MiMo-V2.5-NVFP4`](https://huggingface.co/lukealonso/MiMo-V2.5-NVFP4), the NVFP4 export of MiMo V2.5, on a two-node DGX Spark / GB10 cluster with tensor parallel size 2.
+
+## Validated runtime shape
+
+- vLLM with PR #41797 / `TRITON_ATTN_DIFFKV`
+- `--load-format instanttensor`
+- Omni architecture enabled via `MiMoV2OmniForCausalLM`
+- MiMo MTP speculative decoding enabled with `num_speculative_tokens=2`
+- FlashInfer-CUTLASS MXFP8 dense GEMM
+- FlashInfer-CUTLASS NVFP4 MoE
+- FP8 E4M3 KV cache
+- prefix caching and chunked prefill
+- 131072 max model length
+
+Expected startup markers:
+
+```text
+Resolved architecture: MiMoV2OmniForCausalLM
+Resolved architecture: MiMoV2OmniMTPModel
+Using FlashInferCutlassMxfp8LinearKernel for MXFP8 GEMM
+Using 'FLASHINFER_CUTLASS' NvFp4 MoE backend
+Using TRITON_ATTN_DIFFKV for attention
+Using fp8_e4m3 data type to store kv cache
+Chunked prefill is enabled with max_num_batched_tokens=16384
+```
+
+## Why the mods are required
+
+### `fix-modelopt-mixed-mxfp8`
+
+Adds missing ModelOpt mixed-precision MXFP8 support needed by the NVFP4 export:
+
+- registers a `weight_scale_inv` alias for MXFP8 scale metadata;
+- adds an MXFP8 sub-config to `ModelOptMixedPrecisionConfig`;
+- dispatches `MXFP8` `LinearBase` layers to `ModelOptMxFp8LinearMethod`;
+- dispatches MXFP8 `RoutedExperts` for completeness.
+
+`weight_scale_inv` is UE8M0 scale metadata in this checkpoint path. Do **not** reciprocal-invert it.
+
+### `fix-mimo-v2-vllm`
+
+Applies MiMo-specific runtime fixes:
+
+- registers local `MimoV2Config` when the base vLLM build has the model class but not the config registry entry;
+- preserves explicit text-only architecture overrides for diagnostics;
+- filters non-text checkpoint tensors for text-only runs;
+- fixes Omni vision merger bias mismatch;
+- skips target-model loading of MTP and audio-tokenizer tensors that are loaded/handled separately;
+- replaces blind fused-QKV TP chunking with `QKVParallelLinear.weight_loader` for the NVFP4 checkpoint's `qkv-deinterleaved` layout;
+- applies the same QKV-aware loading to MTP layers;
+- adds Omni `packed_modules_mapping` so fused modules resolve quant metadata;
+- mirrors Omni-remapped MTP quant metadata back to draft `model.mtp.*` prefixes;
+- selects `MiMoV2OmniMTPModel` when a raw MiMo config advertises `vision_config`.
+
+The QKV loader change is critical: the NVFP4 checkpoint stores fused QKV as canonical `[Q_all][K_all][V_all]`, not TP-prepacked `[Q0 K0 V0][Q1 K1 V1]`. Blind `chunk(tp_size, dim=0)` is shape-correct but corrupts K/V rows.
+
+## Basic validation
+
+After launch:
+
+```bash
+curl -s http://localhost:8000/v1/models
+curl -s http://localhost:8000/metrics | grep -E 'cache_config_info|spec_decode'
+```
+
+A short text prompt, a small image prompt, and tool-call requests have been validated with this recipe. Full audio/video validation is still pending.
+
+## Benchmark commands used
+
+Tool eval:
+
+```bash
+tool-eval-bench \
+  --backend vllm \
+  --base-url http://127.0.0.1:8000 \
+  --model MiMo-V2.5-NVFP4 \
+  --seed 42 \
+  --temperature 1.0 \
+  --top-p 0.95 \
+  --timeout 120 \
+  --parallel 1
+```
+
+Observed result in one run: 89/100, 123/138 points, no safety warnings.
+
+Throughput example:
+
+```bash
+llama-benchy \
+  --base-url http://127.0.0.1:8000/v1 \
+  --model lukealonso/MiMo-V2.5-NVFP4 \
+  --served-model-name MiMo-V2.5-NVFP4 \
+  --tokenizer lukealonso/MiMo-V2.5-NVFP4 \
+  --pp 2048 \
+  --tg 32 \
+  --depth 0 4096 8192 16384 32768 65536 98304 114688 131072 \
+  --concurrency 1 2 \
+  --runs 3 \
+  --latency-mode generation \
+  --enable-prefix-caching \
+  --format json
+```

--- a/docs/mimo-v25-nvfp4-dgx-spark.md
+++ b/docs/mimo-v25-nvfp4-dgx-spark.md
@@ -18,6 +18,7 @@ The recipe targets [`lukealonso/MiMo-V2.5-NVFP4`](https://huggingface.co/lukealo
 - FP8 E4M3 KV cache
 - prefix caching and chunked prefill
 - 131072 max model length
+- explicit generation defaults: `temperature=1.0`, `top_p=0.95`, `max_new_tokens=8192`
 
 Expected startup markers:
 

--- a/docs/mimo-v25-nvfp4-dgx-spark.md
+++ b/docs/mimo-v25-nvfp4-dgx-spark.md
@@ -57,7 +57,10 @@ Applies MiMo-specific runtime fixes:
 - applies the same QKV-aware loading to MTP layers;
 - adds Omni `packed_modules_mapping` so fused modules resolve quant metadata;
 - mirrors Omni-remapped MTP quant metadata back to draft `model.mtp.*` prefixes;
-- selects `MiMoV2OmniMTPModel` when a raw MiMo config advertises `vision_config`.
+- selects `MiMoV2OmniMTPModel` when a raw MiMo config advertises `vision_config`;
+- applies vLLM PR #42969 for the Qwen3XML/MiMo streaming tool parser so a
+  closed `<function>` clears `current_function_name` and does not emit duplicate
+  recovery braces.
 
 The QKV loader change is critical: the NVFP4 checkpoint stores fused QKV as canonical `[Q_all][K_all][V_all]`, not TP-prepacked `[Q0 K0 V0][Q1 K1 V1]`. Blind `chunk(tp_size, dim=0)` is shape-correct but corrupts K/V rows.
 

--- a/mods/fix-mimo-v2-vllm/chat_template.jinja
+++ b/mods/fix-mimo-v2-vllm/chat_template.jinja
@@ -1,0 +1,162 @@
+{%- if not add_generation_prompt is defined -%}
+    {%- set add_generation_prompt = false -%}
+{%- endif -%}
+{%- if not enable_thinking is defined -%}
+    {%- set enable_thinking = true -%}
+{%- endif -%}
+{%- if not keep_all_reasoning is defined -%}
+    {%- set keep_all_reasoning = true -%}
+{%- endif -%}
+{%- macro render_extra_keys(json_dict, handled_keys) -%}
+    {%- if json_dict is mapping %}
+        {%- for json_key in json_dict if json_key not in handled_keys %}
+            {%- if json_dict[json_key] is mapping or (json_dict[json_key] is sequence and json_dict[json_key] is not string) %}
+                {{- '\n<' ~ json_key ~ '>' ~ (json_dict[json_key] | tojson | safe) ~ '</' ~ json_key ~ '>' }}
+            {%- else %}
+                {{-'\n<' ~ json_key ~ '>' ~ (json_dict[json_key] | string) ~ '</' ~ json_key ~ '>' }}
+            {%- endif %}
+        {%- endfor %}
+    {%- endif %}
+{%- endmacro -%}
+{%- macro render_content(message_content) -%}
+    {%- if message_content is string -%}
+        {{- message_content -}}
+    {%- else -%}
+        {%- for content in message_content -%}
+            {%- if content['type'] == 'image' or 'image' in content or 'image_url' in content -%}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' -}}
+            {%- elif content['type'] == 'audio' or 'audio' in content or 'audio_url' in content -%}
+                {{- '<|mimo_audio_start|><|audio_pad|><|mimo_audio_end|>' -}}
+            {%- elif content['type'] == 'video' or 'video' in content or 'video_url' in content -%}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' -}}
+            {%- elif 'text' in content -%}
+                {{- content['text'] -}}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
+{%- endmacro -%}
+{%- if messages[0]["role"] == "system" %}
+    {%- set system_message = messages[0]["content"] %}
+    {%- set loop_messages = messages[1:] %}
+{%- else %}
+    {%- set loop_messages = messages %}
+{%- endif %}
+{%- set ns = namespace(last_user_index=-1) %}
+{%- for m in loop_messages %}
+    {%- if m.role == 'user' %}
+        {%- set ns.last_user_index = loop.index0 -%}
+    {%- endif %}
+{%- endfor %}
+{%- if not tools is defined %}
+    {%- set tools = [] %}
+{%- endif %}
+{%- if system_message is defined %}
+    {{- "<|im_start|>system\n" + render_content(system_message) }}
+{%- else %}
+    {{- "<|im_start|>system\nYou are MiMo, a helpful AI assistant engineered by Xiaomi." }}
+{%- endif %}
+{%- if tools is iterable and tools | length > 0 %}
+    {{- "\n\n# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou have access to the following functions:\n\n" }}
+    {{- "<tools>" }}
+    {%- for tool in tools %}
+        {%- if tool.function is defined %}
+            {%- set tool = tool.function %}
+        {%- endif %}
+        {{- "\n<function>\n<name>" ~ tool.name ~ "</name>" }}
+        {%- if tool.description is defined %}
+            {{- '\n<description>' ~ (tool.description | trim) ~ '</description>' }}
+        {%- endif %}
+        {{- '\n<parameters>' }}
+        {%- if tool.parameters is defined and tool.parameters is mapping and tool.parameters.properties is defined and tool.parameters.properties is mapping %}
+            {%- for param_name, param_fields in tool.parameters.properties|items %}
+                {{- '\n<parameter>' }}
+                {{- '\n<name>' ~ param_name ~ '</name>' }}
+                {%- if param_fields.type is defined %}
+                    {{- '\n<type>' ~ (param_fields.type | string) ~ '</type>' }}
+                {%- endif %}
+                {%- if param_fields.description is defined %}
+                    {{- '\n<description>' ~ (param_fields.description | trim) ~ '</description>' }}
+                {%- endif %}
+                {%- set handled_keys = ['name', 'type', 'description'] %}
+                {{- render_extra_keys(param_fields, handled_keys) }}
+                {{- '\n</parameter>' }}
+            {%- endfor %}
+        {%- endif %}
+        {%- set handled_keys = ['type', 'properties'] %}
+        {{- render_extra_keys(tool.parameters, handled_keys) }}
+        {{- '\n</parameters>' }}
+        {%- set handled_keys = ['type', 'name', 'description', 'parameters'] %}
+        {{- render_extra_keys(tool, handled_keys) }}
+        {{- '\n</function>' }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nFor each function call, output the function name and arguments in the following format:\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>value_1</parameter>\n<parameter=example_parameter_2>This is the value for the second parameter\nthat can span\nmultiple lines</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\n- Use the <think>...</think> block for private planning or synthesis.\n- If you need a tool, close </think> first, then output the <tool_call> block immediately after it.\n- If you do not need a tool or already have the needed information, close </think> and answer the user normally.\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags.\n- Do NOT place <tool_call> or <function=...> blocks inside the <think>...</think> reasoning block.\n- The value enclosed between parameter tags is preserved exactly as-is, including newlines and spaces.\n</IMPORTANT>' }}
+{%- endif %}
+{{- '<|im_end|>' }}
+{%- for message in loop_messages %}
+    {%- if message.content is string %}
+        {%- set content = message.content %}
+    {%- else %}
+        {%- set content = render_content(message.content) %}
+    {%- endif %}
+    {%- if message.role == "assistant" %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- set reasoning_content = '' %}
+            {%- if '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].split('<think>')[-1] %}
+                {%- set content = content.split('</think>')[-1] %}
+            {%- endif %}
+        {%- endif %}
+        {%- if (keep_all_reasoning or loop.index0 > ns.last_user_index) and reasoning_content -%}
+            {{- '<|im_start|>' + message.role + '\n<think>' + reasoning_content + '</think>' + content }}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls is defined and message.tool_calls is iterable and message.tool_calls | length > 0 %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- if tool_call.arguments is defined %}
+                    {%- for args_name, args_value in tool_call.arguments|items %}
+                        {{- '<parameter=' + args_name + '>' }}
+                        {%- set args_value = args_value | tojson | safe if args_value is mapping or (args_value is sequence and args_value is not string) else args_value | string %}
+                        {{- args_value }}
+                        {{- '</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>' }}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + render_content(message.content) + '<|im_end|>' }}
+    {%- elif message.role == "system" %}
+        {{- '<|im_start|>' + message.role + '\n' + render_content(message.content) + '<|im_end|>' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>tool\n' }}
+        {%- endif %}
+        {{- '<tool_response>\n' }}
+        {{- render_content(message.content) }}
+        {{- '\n</tool_response>\n' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>' }}
+        {%- endif %}
+    {%- else %}
+        {{- '<|im_start|>' + message.role + '\n' + render_content(message.content) + '<|im_end|>' }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if not enable_thinking -%}
+        {{- '<think></think>' -}}
+    {%- else -%}
+        {{- '<think>' -}}
+    {%- endif -%}
+{%- endif %}

--- a/mods/fix-mimo-v2-vllm/run.sh
+++ b/mods/fix-mimo-v2-vllm/run.sh
@@ -1,0 +1,535 @@
+#!/bin/bash
+set -euo pipefail
+
+SITE_PACKAGES="/usr/local/lib/python3.12/dist-packages"
+PR41797_URL="https://patch-diff.githubusercontent.com/raw/vllm-project/vllm/pull/41797.diff"
+
+cd "$SITE_PACKAGES"
+
+echo "[fix-mimo-v2-vllm] Applying MiMo V2.5 vLLM fixes"
+
+# CyberTen forum note: vLLM's multimodal audio path uses soundfile + librosa,
+# not torchcodec. Keep this harmless for text-only runs and necessary for audio.
+python3 - <<'PY' || uv pip install --quiet soundfile librosa
+import soundfile  # noqa: F401
+import librosa  # noqa: F401
+PY
+
+# Some current vLLM builds have the MiMo V2 model class but not a HF config
+# registry entry for model_type=mimo_v2. Transformers then tries to fetch a
+# nonexistent remote configuration_mimo_v2.py from the NVFP4 repo and aborts
+# before vLLM can select its local model implementation.
+echo "[fix-mimo-v2-vllm] Installing local MiMoV2Config registration if needed"
+cat > "$SITE_PACKAGES/vllm/transformers_utils/configs/mimo_v2.py" <<'PY'
+# SPDX-License-Identifier: Apache-2.0
+from transformers import PretrainedConfig
+
+
+class MimoV2Config(PretrainedConfig):
+    model_type = "mimo_v2"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+PY
+python3 - <<'PY'
+from pathlib import Path
+site = Path('/usr/local/lib/python3.12/dist-packages')
+init = site / 'vllm/transformers_utils/configs/__init__.py'
+text = init.read_text()
+if '"MimoV2Config": "vllm.transformers_utils.configs.mimo_v2"' not in text:
+    text = text.replace(
+        '    "MiDashengLMConfig": "vllm.transformers_utils.configs.midashenglm",\n',
+        '    "MiDashengLMConfig": "vllm.transformers_utils.configs.midashenglm",\n'
+        '    "MimoV2Config": "vllm.transformers_utils.configs.mimo_v2",\n',
+    )
+if '    "MimoV2Config",\n' not in text:
+    text = text.replace(
+        '    "MiDashengLMConfig",\n',
+        '    "MiDashengLMConfig",\n'
+        '    "MimoV2Config",\n',
+    )
+init.write_text(text)
+
+cfg = site / 'vllm/transformers_utils/config.py'
+text = cfg.read_text()
+if 'mimo_v2="MimoV2Config"' not in text:
+    text = text.replace(
+        '    midashenglm="MiDashengLMConfig",\n',
+        '    midashenglm="MiDashengLMConfig",\n'
+        '    mimo_v2="MimoV2Config",\n',
+    )
+cfg.write_text(text)
+PY
+
+# Respect an explicit text-only architecture override. Current vLLM's MiMoV2
+# arch convertor unconditionally rewrites any config containing vision_config to
+# MiMoV2OmniForCausalLM, even when the launch passes
+# --hf-overrides '{"architectures":["MiMoV2ForCausalLM"]}'. That makes text-only
+# bring-up load the vision/audio modules and currently fails on missing merger
+# bias weights in this NVFP4 export.
+python3 - <<'PY'
+from pathlib import Path
+path = Path('/usr/local/lib/python3.12/dist-packages/vllm/transformers_utils/model_arch_config_convertor.py')
+text = path.read_text()
+old = '''class MimoV2ModelArchConfigConvertor(ModelArchConfigConvertorBase):
+    def __init__(self, hf_config: PretrainedConfig, hf_text_config: PretrainedConfig):
+        if getattr(hf_config, "vision_config", None):
+            hf_config.architectures = ["MiMoV2OmniForCausalLM"]
+        super().__init__(hf_config, hf_text_config)
+        _strip_mimo_v2_attention_chunk_size(hf_config, hf_text_config)
+'''
+new = '''class MimoV2ModelArchConfigConvertor(ModelArchConfigConvertorBase):
+    def __init__(self, hf_config: PretrainedConfig, hf_text_config: PretrainedConfig):
+        # Preserve explicit text-only override for MiMo-V2.5 NVFP4 bring-up.
+        # The checkpoint config includes vision/audio sections, but text-only
+        # serving should use MiMoV2ForCausalLM when requested via hf_overrides.
+        if getattr(hf_config, "vision_config", None) and getattr(
+            hf_config, "architectures", None
+        ) != ["MiMoV2ForCausalLM"]:
+            hf_config.architectures = ["MiMoV2OmniForCausalLM"]
+        super().__init__(hf_config, hf_text_config)
+        _strip_mimo_v2_attention_chunk_size(hf_config, hf_text_config)
+'''
+if old in text:
+    path.write_text(text.replace(old, new, 1))
+    print('[fix-mimo-v2-vllm] patched MimoV2 arch convertor to preserve text-only override')
+elif 'Preserve explicit text-only override for MiMo-V2.5 NVFP4 bring-up' in text:
+    print('[fix-mimo-v2-vllm] MimoV2 arch convertor already patched')
+else:
+    raise SystemExit('[fix-mimo-v2-vllm] ERROR: MimoV2 arch convertor pattern not found')
+PY
+
+# Text-only MiMoV2ForCausalLM should ignore multimodal and MTP weights present
+# in the Omni/NVFP4 checkpoint. AutoWeightsLoader otherwise treats e.g.
+# visual.* as an unknown module and aborts.
+python3 - <<'PY'
+from pathlib import Path
+path = Path('/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/mimo_v2.py')
+text = path.read_text()
+old = '''    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(self)
+        return loader.load_weights(weights)
+'''
+new = '''    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        def text_only_weights():
+            skip_prefixes = (
+                "visual.",
+                "audio_encoder.",
+                "speech_embeddings.",
+                "model.mtp.",
+            )
+            for name, tensor in weights:
+                if name.startswith(skip_prefixes):
+                    continue
+                yield name, tensor
+
+        loader = AutoWeightsLoader(self)
+        return loader.load_weights(text_only_weights())
+'''
+if old in text:
+    path.write_text(text.replace(old, new, 1))
+    print('[fix-mimo-v2-vllm] patched MiMoV2ForCausalLM.load_weights to skip non-text checkpoint tensors')
+elif 'def text_only_weights():' in text and 'speech_embeddings.' in text:
+    print('[fix-mimo-v2-vllm] MiMoV2 text-only weight filter already patched')
+else:
+    raise SystemExit('[fix-mimo-v2-vllm] ERROR: MiMoV2 load_weights pattern not found')
+PY
+
+# Omni/multimodal fixes for this checkpoint:
+# - The reference MiMo vision merger uses biased Linear layers and the NVFP4
+#   checkpoint contains visual.merger.mlp.{0,2}.bias.  vLLM's local MiMo copy
+#   had these as bias=False, causing unknown/missing bias handling and an
+#   architecture mismatch.
+# - Target Omni model loading should skip MTP weights; the MTP drafter loads
+#   those separately.
+# - The top-level Omni class is SupportsQuant, so it is the class that mutates
+#   ModelOptMixedPrecisionConfig.  Without a packed_modules_mapping on Omni,
+#   nested language_model.model.layers.*.mlp.gate_up_proj does not resolve the
+#   checkpoint's separate gate_proj/up_proj quantization entries and is treated
+#   as unquantized, corrupting the target text path even for text-only requests.
+python3 - <<'PY'
+from pathlib import Path
+path = Path('/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/mimo_v2_omni.py')
+text = path.read_text()
+orig = text
+old = '''class MiMoV2OmniForCausalLM(nn.Module, SupportsMultiModal, SupportsPP, SupportsQuant):
+    # To ensure correct weight loading and mapping.
+    hf_to_vllm_mapper = WeightsMapper(
+'''
+new = '''class MiMoV2OmniForCausalLM(nn.Module, SupportsMultiModal, SupportsPP, SupportsQuant):
+    # Ensure ModelOpt mixed-precision resolves fused language/MTP modules after
+    # the Omni hf_to_vllm prefix mapper rewrites model.* -> language_model.model.*.
+    packed_modules_mapping = {
+        "qkv_proj": ["qkv_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+
+    # To ensure correct weight loading and mapping.
+    hf_to_vllm_mapper = WeightsMapper(
+'''
+if new not in text:
+    if old not in text:
+        raise SystemExit('[fix-mimo-v2-vllm] ERROR: MiMoV2Omni class anchor not found')
+    text = text.replace(old, new, 1)
+text = text.replace(
+'''            ColumnParallelLinear(
+                self.hidden_size,
+                self.hidden_size,
+                bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.mlp.0",
+''',
+'''            ColumnParallelLinear(
+                self.hidden_size,
+                self.hidden_size,
+                bias=True,
+                quant_config=quant_config,
+                prefix=f"{prefix}.mlp.0",
+''',
+1)
+text = text.replace(
+'''            RowParallelLinear(
+                self.hidden_size,
+                d_model,
+                bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.mlp.2",
+''',
+'''            RowParallelLinear(
+                self.hidden_size,
+                d_model,
+                bias=True,
+                quant_config=quant_config,
+                prefix=f"{prefix}.mlp.2",
+''',
+1)
+old = '''        loader = AutoWeightsLoader(self, skip_prefixes=["audio_tokenizer."])
+        auto_loaded = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+'''
+new = '''        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=[
+                "audio_tokenizer.",
+                # After hf_to_vllm_mapper, checkpoint model.mtp.* becomes
+                # language_model.model.mtp.*.  The target model should ignore
+                # it; MiMoV2MTP/OmniMTP loads these weights separately.
+                "language_model.model.mtp.",
+            ],
+        )
+        auto_loaded = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+'''
+if new not in text:
+    if old not in text:
+        raise SystemExit('[fix-mimo-v2-vllm] ERROR: MiMoV2Omni load_weights skip pattern not found')
+    text = text.replace(old, new, 1)
+if text != orig:
+    path.write_text(text)
+    print('[fix-mimo-v2-vllm] patched MiMoV2Omni vision merger bias and MTP skip')
+else:
+    print('[fix-mimo-v2-vllm] MiMoV2Omni multimodal fixes already patched')
+PY
+
+# MiMo-V2.5-NVFP4/chimera stores fused qkv_proj tensors as canonical
+# [Q_all][K_all][V_all] (see checkpoint metadata: qkv-deinterleaved).  The
+# upstream MiMoV2 loader has a Pro-format shortcut that blindly chunks the
+# fused row dimension by TP rank; that is shape-correct but semantically wrong
+# for this checkpoint because K/V slots receive Q rows.  Let QKVParallelLinear's
+# native fused-QKV loader split Q/K/V and their MXFP8 scale rows correctly.
+python3 - <<'PY'
+from pathlib import Path
+path = Path('/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/mimo_v2.py')
+text = path.read_text()
+old = '''            # Support fused qkv_proj checkpoint (Pro format)
+            if "qkv_proj" in name:
+                if name in params_dict:
+                    param = params_dict[name]
+                    loaded_weight = loaded_weight.chunk(tp_size, dim=0)[tp_rank]
+                    default_weight_loader(param, loaded_weight)
+                continue
+'''
+new = '''            # MiMo-V2.5-NVFP4/chimera stores fused qkv_proj tensors as
+            # canonical [Q_all][K_all][V_all] (checkpoint metadata says
+            # qkv-deinterleaved), not the native FP8 Pro TP-prepacked layout
+            # [Q0 K0 V0][Q1 K1 V1]...
+            #
+            # A blind chunk(tp_size, dim=0) is shape-correct for TP=2 but
+            # semantically corrupts K/V rows and the row-aligned MXFP8
+            # weight_scale_inv tensors.  Use QKVParallelLinear.weight_loader so
+            # each rank receives [Q_rank][K_rank][V_rank].
+            if "qkv_proj" in name:
+                if name in params_dict:
+                    param = params_dict[name]
+                    weight_loader = getattr(
+                        param, "weight_loader", default_weight_loader
+                    )
+                    weight_loader(param, loaded_weight)
+                    loaded_params.add(name)
+                continue
+'''
+if new not in text:
+    if old not in text:
+        raise SystemExit('[fix-mimo-v2-vllm] ERROR: MiMoV2 qkv_proj loader shortcut pattern not found')
+    path.write_text(text.replace(old, new, 1))
+    print('[fix-mimo-v2-vllm] patched MiMoV2 fused qkv_proj loader to use QKVParallelLinear.weight_loader')
+else:
+    print('[fix-mimo-v2-vllm] MiMoV2 fused qkv_proj loader already patched')
+PY
+
+# Apply the same qkv-deinterleaved handling to the MiMo-V2 MTP draft model.
+# The NVFP4 checkpoint includes MTP qkv_proj tensors in the same canonical
+# [Q_all][K_all][V_all] layout.  Also keep duplicate parameter aliases when
+# building params_dict so `.weight_scale_inv` checkpoint tensors load into the
+# MXFP8 `weight_scale` alias registered by fix-modelopt-mixed-mxfp8.
+#
+# Critical Omni+MTP quant fix: MiMoV2OmniForCausalLM's hf_to_vllm_mapper rewrites
+# checkpoint quantized_layers from model.* to language_model.model.* so the Omni
+# target layers quantize correctly.  That same global QuantizationConfig is then
+# reused for the MTP drafter, whose prefixes are still model.mtp.layers.*.  Mirror
+# language_model.model.mtp.* quant metadata back to model.mtp.* when the draft
+# class is initialized, otherwise OmniMTP layers silently become unquantized.
+python3 - <<'PY'
+from pathlib import Path
+path = Path('/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/mimo_v2_mtp.py')
+text = path.read_text()
+orig = text
+old = '''from .utils import _merge_multimodal_embeddings, maybe_prefix
+'''
+new = '''from .utils import WeightsMapper, _merge_multimodal_embeddings, maybe_prefix
+'''
+if new not in text:
+    if old not in text:
+        raise SystemExit('[fix-mimo-v2-vllm] ERROR: MiMoV2MTP utils import pattern not found')
+    text = text.replace(old, new, 1)
+
+old = '''class MiMoV2MTP(nn.Module):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+'''
+new = '''class MiMoV2MTP(nn.Module):
+    packed_modules_mapping = {
+        "qkv_proj": ["qkv_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={
+            # Undo the Omni target mapper for MTP draft quant metadata only.
+            "language_model.model.mtp.": "model.mtp.",
+        }
+    )
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+'''
+if new not in text:
+    if old not in text:
+        raise SystemExit('[fix-mimo-v2-vllm] ERROR: MiMoV2MTP class anchor not found')
+    text = text.replace(old, new, 1)
+
+old = '''        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+'''
+new = '''        # Keep duplicate aliases such as MXFP8 `weight_scale` /
+        # `weight_scale_inv`; the checkpoint uses the latter.
+        params_dict = dict(self.named_parameters(remove_duplicate=False))
+        loaded_params: set[str] = set()
+'''
+if new not in text:
+    if old not in text:
+        raise SystemExit('[fix-mimo-v2-vllm] ERROR: MiMoV2MTP params_dict pattern not found')
+    text = text.replace(old, new, 1)
+
+old = '''            # Support fused qkv_proj checkpoint (Pro format).
+            # The checkpoint is stored pre-sharded for TP=8 as
+            # [Q_rank0, K_rank0, V_rank0, Q_rank1, ...], so splitting along
+            # dim 0 with chunk(tp_size) gives each rank its Q+K+V slice for
+            # both the FP8 weight and the block weight_scale_inv. This matches
+            # how the main model loads the same layout.
+            if "qkv_proj" in name:
+                if name in params_dict:
+                    param = params_dict[name]
+                    loaded_weight = loaded_weight.chunk(tp_size, dim=0)[tp_rank]
+                    default_weight_loader(param, loaded_weight)
+                    loaded_params.add(name)
+                continue
+'''
+new = '''            # MiMo-V2.5-NVFP4/chimera MTP qkv_proj tensors are canonical
+            # [Q_all][K_all][V_all], not TP-prepacked Pro layout.  Use
+            # QKVParallelLinear.weight_loader for Q/K/V-aware TP slicing of
+            # both FP8 weights and row-aligned MXFP8 weight_scale_inv tensors.
+            if "qkv_proj" in name:
+                if name in params_dict:
+                    param = params_dict[name]
+                    weight_loader = getattr(
+                        param, "weight_loader", default_weight_loader
+                    )
+                    weight_loader(param, loaded_weight)
+                    loaded_params.add(name)
+                continue
+'''
+if new not in text:
+    if old not in text:
+        raise SystemExit('[fix-mimo-v2-vllm] ERROR: MiMoV2MTP qkv_proj loader shortcut pattern not found')
+    text = text.replace(old, new, 1)
+
+if text != orig:
+    path.write_text(text)
+    print('[fix-mimo-v2-vllm] patched MiMoV2MTP quant mapping and qkv-deinterleaved MXFP8 loader')
+else:
+    print('[fix-mimo-v2-vllm] MiMoV2MTP quant mapping and loader already patched')
+PY
+
+# MiMo-V2.5 Omni checkpoints may keep the raw HF architecture as
+# MiMoV2ForCausalLM even though the target model is resolved to
+# MiMoV2OmniForCausalLM because vision/audio config is present or because the
+# launch passes an Omni hf override.  The speculative draft ModelConfig reloads
+# the raw checkpoint config and applies only SpeculativeConfig.hf_config_override;
+# without this patch the draft resolves to text-only MiMoV2MTPModel instead of
+# the official multimodal MiMoV2OmniMTPModel wrapper.  Select OmniMTP whenever
+# the draft checkpoint advertises vision_config.
+python3 - <<'PY'
+from pathlib import Path
+path = Path('/usr/local/lib/python3.12/dist-packages/vllm/config/speculative.py')
+text = path.read_text()
+old = '''        if (arch := hf_config.architectures[0]) in (
+            "MiMoV2ForCausalLM",
+            "MiMoV2OmniForCausalLM",
+        ):
+            from vllm.model_executor.models.mimo_v2_mtp import (
+                _MIMO_V2_PRO_NUM_MTP_LAYERS,
+            )
+
+            mtp_arch_maps = {
+                "MiMoV2ForCausalLM": "MiMoV2MTPModel",
+                "MiMoV2OmniForCausalLM": "MiMoV2OmniMTPModel",
+            }
+
+            hf_config.model_type = "mimo_v2_mtp"
+'''
+new = '''        if (arch := hf_config.architectures[0]) in (
+            "MiMoV2ForCausalLM",
+            "MiMoV2OmniForCausalLM",
+        ):
+            from vllm.model_executor.models.mimo_v2_mtp import (
+                _MIMO_V2_PRO_NUM_MTP_LAYERS,
+            )
+
+            # The raw HF config for some Omni-capable MiMo-V2.5 exports still
+            # says MiMoV2ForCausalLM even though vision/audio config is present.
+            # The target may be resolved to MiMoV2OmniForCausalLM, but the MTP
+            # draft config only sees the raw checkpoint architecture.  Mirror
+            # the official Omni MTP path for such checkpoints.
+            if arch == "MiMoV2ForCausalLM" and getattr(
+                hf_config, "vision_config", None
+            ):
+                arch = "MiMoV2OmniForCausalLM"
+
+            mtp_arch_maps = {
+                "MiMoV2ForCausalLM": "MiMoV2MTPModel",
+                "MiMoV2OmniForCausalLM": "MiMoV2OmniMTPModel",
+            }
+
+            hf_config.model_type = "mimo_v2_mtp"
+'''
+if new not in text:
+    if old not in text:
+        raise SystemExit('[fix-mimo-v2-vllm] ERROR: SpeculativeConfig MiMoV2 MTP mapping pattern not found')
+    path.write_text(text.replace(old, new, 1))
+    print('[fix-mimo-v2-vllm] patched SpeculativeConfig to select MiMoV2OmniMTPModel for Omni exports')
+else:
+    print('[fix-mimo-v2-vllm] SpeculativeConfig Omni MTP mapping already patched')
+PY
+
+# PR #41797: add TRITON_ATTN_DIFFKV and make MiMoV2 auto-fallback to it on
+# non-FA3 hardware (GB10/sm_121a). Without this, MiMoV2's K/V head-dim split
+# forces FlashAttentionDiffKV and fails on DGX Spark.
+if python3 - <<'PY'
+import importlib.util
+raise SystemExit(0 if importlib.util.find_spec('vllm.v1.attention.backends.triton_attn_diffkv') else 1)
+PY
+then
+    echo "[fix-mimo-v2-vllm] TRITON_ATTN_DIFFKV already present; skipping PR #41797"
+else
+    echo "[fix-mimo-v2-vllm] Applying vLLM PR #41797 (TRITON_ATTN_DIFFKV)"
+    tmpdir="$(mktemp -d)"
+    trap 'rm -rf "$tmpdir"' EXIT
+    curl -fsL "$PR41797_URL" -o "$tmpdir/pr41797.diff"
+
+    # The upstream diff contains docs; only apply package files under vllm/.
+    python3 - "$tmpdir/pr41797.diff" "$tmpdir/pr41797-vllm-only.diff" <<'PY'
+from pathlib import Path
+import sys
+src = Path(sys.argv[1])
+dst = Path(sys.argv[2])
+keep = False
+out = []
+for line in src.read_text().splitlines(True):
+    if line.startswith('diff --git '):
+        parts = line.strip().split()
+        # format: diff --git a/path b/path
+        b_path = parts[3][2:] if len(parts) >= 4 and parts[3].startswith('b/') else ''
+        keep = b_path.startswith('vllm/')
+    if keep:
+        out.append(line)
+dst.write_text(''.join(out))
+PY
+
+    if git apply --check --unsafe-paths "$tmpdir/pr41797-vllm-only.diff"; then
+        git apply --unsafe-paths --whitespace=nowarn "$tmpdir/pr41797-vllm-only.diff"
+    elif patch -p1 --dry-run --forward --batch < "$tmpdir/pr41797-vllm-only.diff" >/dev/null 2>&1; then
+        patch -p1 --forward --batch < "$tmpdir/pr41797-vllm-only.diff"
+    else
+        echo "[fix-mimo-v2-vllm] ERROR: PR #41797 is not applicable to this vLLM install" >&2
+        echo "[fix-mimo-v2-vllm] Rebuild with --apply-vllm-pr 41797 or update the base image." >&2
+        exit 1
+    fi
+fi
+
+# CyberTen's #41834 minimal fallback for V2 executor + MTP + cudagraph.
+# Newer vLLM already contains this; older builds may not. Apply only when the
+# exact anchor exists and the snippet is absent.
+GPU_RUNNER="$SITE_PACKAGES/vllm/v1/worker/gpu_model_runner.py"
+if [ -f "$GPU_RUNNER" ] && ! grep -q "sync_without_prev_positions" "$GPU_RUNNER"; then
+    echo "[fix-mimo-v2-vllm] Applying minimal sync_without_prev_positions fallback"
+    python3 - "$GPU_RUNNER" <<'PY'
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+text = path.read_text()
+anchors = [
+    "        prev_positions = self.prev_positions.np[: len(num_draft_tokens)]\n",
+    "        prev_positions = self.prev_positions.np[:len(num_draft_tokens)]\n",
+]
+snippet = '''\
+        sync_without_prev_positions = (\n            not self.use_async_scheduling and np.all(prev_positions < 0)\n        )\n        if sync_without_prev_positions:\n            if draft_probs.ndim == 2:\n                return draft_probs[:total_num_draft_tokens].contiguous()\n            if draft_probs.shape[0] >= len(num_draft_tokens):\n                prev_positions = np.arange(len(num_draft_tokens))\n            else:\n                packed_probs = []\n                draft_row = 0\n                for num_tokens in num_draft_tokens:\n                    if num_tokens == 0:\n                        continue\n                    if draft_row >= draft_probs.shape[0]:\n                        raise RuntimeError(\n                            "Spec decode metadata references more draft token "\n                            "rows than were recorded by the draft model."\n                        )\n                    packed_probs.append(draft_probs[draft_row, :num_tokens])\n                    draft_row += 1\n                if not packed_probs:\n                    return None\n                return torch.cat(packed_probs, dim=0).contiguous()\n'''
+for anchor in anchors:
+    if anchor in text:
+        path.write_text(text.replace(anchor, anchor + snippet, 1))
+        print("[fix-mimo-v2-vllm] patched", path)
+        break
+else:
+    print("[fix-mimo-v2-vllm] anchor not found; skipping #41834 fallback (likely different vLLM version)")
+PY
+else
+    echo "[fix-mimo-v2-vllm] sync_without_prev_positions already present or gpu_model_runner.py missing; skipping"
+fi
+
+find "$SITE_PACKAGES/vllm" -name __pycache__ -type d -prune -exec rm -rf {} + 2>/dev/null || true
+
+python3 - <<'PY'
+import importlib.util
+assert importlib.util.find_spec('vllm.v1.attention.backends.triton_attn_diffkv'), 'TRITON_ATTN_DIFFKV not installed'
+from vllm.transformers_utils.config import _CONFIG_REGISTRY
+assert 'mimo_v2' in _CONFIG_REGISTRY, 'mimo_v2 config registry entry missing'
+from vllm.config.speculative import SpeculativeConfig
+from vllm.transformers_utils.configs.mimo_v2 import MimoV2Config
+cfg = MimoV2Config(architectures=['MiMoV2ForCausalLM'], vision_config={'enabled': True})
+out = SpeculativeConfig.hf_config_override(cfg)
+assert out.architectures == ['MiMoV2OmniMTPModel'], out.architectures
+from vllm.model_executor.models.mimo_v2_mtp import MiMoV2MTP
+mapped = MiMoV2MTP.hf_to_vllm_mapper.apply_dict({
+    'language_model.model.mtp.layers.0.self_attn.qkv_proj': {'quant_algo': 'MXFP8'},
+    'language_model.model.layers.0.self_attn.qkv_proj': {'quant_algo': 'MXFP8'},
+})
+assert 'model.mtp.layers.0.self_attn.qkv_proj' in mapped, mapped
+assert 'language_model.model.layers.0.self_attn.qkv_proj' in mapped, mapped
+assert MiMoV2MTP.packed_modules_mapping['gate_up_proj'] == ['gate_proj', 'up_proj']
+print('[fix-mimo-v2-vllm] validation OK')
+PY

--- a/mods/fix-mimo-v2-vllm/run.sh
+++ b/mods/fix-mimo-v2-vllm/run.sh
@@ -15,6 +15,36 @@ import soundfile  # noqa: F401
 import librosa  # noqa: F401
 PY
 
+# PR #42969: the "mimo" tool parser is an alias for Qwen3XMLToolParser.  When
+# the streaming XML parser closes a <function> element it already marks the
+# function closed, but older vLLM builds leave current_function_name populated.
+# Fallback recovery can then treat the function as still active and emit an
+# extra closing brace in streamed tool-call deltas.
+python3 - <<'PY'
+from pathlib import Path
+path = Path('/usr/local/lib/python3.12/dist-packages/vllm/tool_parsers/qwen3xml_tool_parser.py')
+if not path.exists():
+    print('[fix-mimo-v2-vllm] qwen3xml tool parser not present; skipping PR #42969')
+    raise SystemExit
+text = path.read_text()
+old = '''            self.current_function_open = False
+
+        elif name == "tool_call":
+'''
+new = '''            self.current_function_open = False
+            self.current_function_name = None
+
+        elif name == "tool_call":
+'''
+if new in text:
+    print('[fix-mimo-v2-vllm] Qwen3XML/MiMo tool parser PR #42969 already patched')
+elif old in text:
+    path.write_text(text.replace(old, new, 1))
+    print('[fix-mimo-v2-vllm] patched Qwen3XML/MiMo streaming tool parser (#42969)')
+else:
+    raise SystemExit('[fix-mimo-v2-vllm] ERROR: Qwen3XML tool parser pattern not found for PR #42969')
+PY
+
 # Some current vLLM builds have the MiMo V2 model class but not a HF config
 # registry entry for model_type=mimo_v2. Transformers then tries to fetch a
 # nonexistent remote configuration_mimo_v2.py from the NVFP4 repo and aborts

--- a/mods/fix-mimo-v2-vllm/run.sh
+++ b/mods/fix-mimo-v2-vllm/run.sh
@@ -3,10 +3,18 @@ set -euo pipefail
 
 SITE_PACKAGES="/usr/local/lib/python3.12/dist-packages"
 PR41797_URL="https://patch-diff.githubusercontent.com/raw/vllm-project/vllm/pull/41797.diff"
+MOD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 cd "$SITE_PACKAGES"
 
 echo "[fix-mimo-v2-vllm] Applying MiMo V2.5 vLLM fixes"
+
+if [ ! -f "$MOD_DIR/chat_template.jinja" ]; then
+    echo "[fix-mimo-v2-vllm] ERROR: fixed MiMo chat_template.jinja missing from mod directory: $MOD_DIR" >&2
+    exit 1
+fi
+
+echo "[fix-mimo-v2-vllm] fixed MiMo chat template available at $MOD_DIR/chat_template.jinja"
 
 # CyberTen forum note: vLLM's multimodal audio path uses soundfile + librosa,
 # not torchcodec. Keep this harmless for text-only runs and necessary for audio.
@@ -43,6 +51,233 @@ elif old in text:
     print('[fix-mimo-v2-vllm] patched Qwen3XML/MiMo streaming tool parser (#42969)')
 else:
     raise SystemExit('[fix-mimo-v2-vllm] ERROR: Qwen3XML tool parser pattern not found for PR #42969')
+PY
+
+# vLLM currently aliases the MiMo reasoning parser to Qwen3ReasoningParser.
+# That parser decides whether streaming output has already left the reasoning
+# phase by scanning the whole prompt for the last <think>/</think> token.  The
+# MiMo V2.5 template does NOT prefill <think> for thinking-on generation, but
+# the rendered prompt can contain closed <think></think> spans in tool
+# instructions and assistant history.  The generic scan then marks reasoning as
+# already ended before generation starts, so generated <think>...</think> is
+# routed through the tool parser as ordinary content.  Install a tiny MiMo
+# subclass that treats the fresh assistant generation prompt as reasoning-open
+# unless the prompt explicitly ends with the thinking-off <think></think> stub.
+echo "[fix-mimo-v2-vllm] Installing MiMo-specific reasoning parser prompt-state fix"
+cat > "$SITE_PACKAGES/vllm/reasoning/mimo_reasoning_parser.py" <<'PY'
+# SPDX-License-Identifier: Apache-2.0
+from collections.abc import Sequence
+
+from vllm.reasoning.qwen3_reasoning_parser import Qwen3ReasoningParser
+
+
+class MimoReasoningParser(Qwen3ReasoningParser):
+    """MiMo V2.5 reasoning parser.
+
+    MiMo's chat template leaves the assistant generation prompt at
+    ``<|im_start|>assistant\n`` when thinking is enabled.  Closed think tags
+    can still occur earlier in the prompt (tool instructions say
+    ``<think></think>`` and assistant history is rendered with think spans), so
+    Qwen3ReasoningParser.is_reasoning_end(prompt_ids) can return True before
+    any new assistant tokens have been generated.  That leaks generated
+    ``<think>`` text as normal content and confuses streamed tool-call parsing.
+    """
+
+    def __init__(self, tokenizer, *args, **kwargs):
+        super().__init__(tokenizer, *args, **kwargs)
+        self._assistant_generation_prefix_token_ids = tokenizer.encode(
+            "<|im_start|>assistant\n", add_special_tokens=False
+        )
+        self._assistant_thinking_disabled_suffix_token_ids = tokenizer.encode(
+            "<|im_start|>assistant\n<think></think>", add_special_tokens=False
+        )
+
+    @staticmethod
+    def _endswith(input_ids: Sequence[int], suffix: Sequence[int]) -> bool:
+        if not suffix or len(input_ids) < len(suffix):
+            return False
+        return list(input_ids[-len(suffix) :]) == list(suffix)
+
+    def is_reasoning_end(self, input_ids: Sequence[int]) -> bool:
+        # This is the prompt-time check used by vLLM before streaming starts.
+        # If generation is about to begin after the bare assistant prefix,
+        # reasoning is open even if earlier prompt text contains </think>.
+        if self._endswith(input_ids, self._assistant_generation_prefix_token_ids):
+            return False
+
+        # Thinking-off MiMo prompts end with an explicit empty reasoning span;
+        # in that case output should be routed as content/tool text immediately.
+        if self._endswith(
+            input_ids, self._assistant_thinking_disabled_suffix_token_ids
+        ):
+            return True
+
+        return super().is_reasoning_end(input_ids)
+PY
+python3 - <<'PY'
+from pathlib import Path
+path = Path('/usr/local/lib/python3.12/dist-packages/vllm/reasoning/__init__.py')
+text = path.read_text()
+old = '''    "mimo": (
+        "qwen3_reasoning_parser",
+        "Qwen3ReasoningParser",
+    ),
+'''
+new = '''    "mimo": (
+        "mimo_reasoning_parser",
+        "MimoReasoningParser",
+    ),
+'''
+if new in text:
+    print('[fix-mimo-v2-vllm] MiMo reasoning parser alias already patched')
+elif old in text:
+    path.write_text(text.replace(old, new, 1))
+    print('[fix-mimo-v2-vllm] patched MiMo reasoning parser alias')
+else:
+    raise SystemExit('[fix-mimo-v2-vllm] ERROR: MiMo reasoning parser alias pattern not found')
+PY
+
+# Harden Qwen3XML/MiMo streaming deltas for OpenAI-compatible clients.  The
+# parser emits terminal tool-call deltas with name=None and arguments=""; some
+# clients/frontends treat those as separate empty calls (displayed as {}).  Also
+# avoid constructing DeltaMessage(tool_calls=[]) for ordinary text chunks,
+# because Pydantic marks the empty list as explicitly set and serializes it.
+python3 - <<'PY'
+from pathlib import Path
+path = Path('/usr/local/lib/python3.12/dist-packages/vllm/tool_parsers/qwen3xml_tool_parser.py')
+if not path.exists():
+    print('[fix-mimo-v2-vllm] qwen3xml tool parser not present; skipping empty-delta hardening')
+    raise SystemExit
+text = path.read_text()
+orig = text
+old = '''        return DeltaMessage(
+            content=merged_content if merged_content else None,
+            tool_calls=merged_tool_calls,
+        )
+'''
+new = '''        kwargs = {}
+        if merged_content:
+            kwargs["content"] = merged_content
+        if merged_tool_calls:
+            kwargs["tool_calls"] = merged_tool_calls
+        return DeltaMessage(**kwargs)
+'''
+if new not in text:
+    if old not in text:
+        raise SystemExit('[fix-mimo-v2-vllm] ERROR: Qwen3XML merge return pattern not found')
+    text = text.replace(old, new, 1)
+old = '''        elif name.startswith("function") or name == "function":
+            # if there are parameters, close JSON object
+            if self.parameters:
+'''
+new = '''        elif name.startswith("function") or name == "function":
+            # Ignore malformed/empty <function> blocks that never provided a
+            # name; otherwise a bare <tool_call></tool_call> can become an
+            # empty OpenAI tool call with `{}` arguments.
+            if not self.current_function_name:
+                self.current_function_open = False
+                return
+
+            # if there are parameters, close JSON object
+            if self.parameters:
+'''
+if new not in text:
+    if old not in text:
+        raise SystemExit('[fix-mimo-v2-vllm] ERROR: Qwen3XML function-end guard pattern not found')
+    text = text.replace(old, new, 1)
+old = '''        # Parse the delta text and get the result
+        delta = self.parser.parse_single_streaming_chunks(delta_text)
+
+        # Update tool call tracking arrays based on incremental parsing results
+        if delta and delta.tool_calls:
+'''
+new = '''        # Parse the delta text and get the result
+        delta = self.parser.parse_single_streaming_chunks(delta_text)
+
+        # Drop terminal no-op tool-call deltas.  They carry no name and no
+        # argument bytes; retaining them makes less defensive clients create a
+        # second empty tool call.
+        if delta and delta.tool_calls:
+            meaningful_tool_calls = []
+            for tool_call in delta.tool_calls:
+                function = tool_call.function
+                if function and (function.name is not None or function.arguments not in (None, "")):
+                    meaningful_tool_calls.append(tool_call)
+            if len(meaningful_tool_calls) != len(delta.tool_calls):
+                delta.tool_calls = meaningful_tool_calls
+
+        # Update tool call tracking arrays based on incremental parsing results
+        if delta and delta.tool_calls:
+'''
+if new not in text:
+    if old not in text:
+        raise SystemExit('[fix-mimo-v2-vllm] ERROR: Qwen3XML streaming filter insertion pattern not found')
+    text = text.replace(old, new, 1)
+if text != orig:
+    path.write_text(text)
+    print('[fix-mimo-v2-vllm] hardened Qwen3XML/MiMo streaming empty tool-call deltas')
+else:
+    print('[fix-mimo-v2-vllm] Qwen3XML/MiMo streaming empty-delta hardening already patched')
+PY
+
+# Optional MiMo reasoning budget default.  Some clients (including agent
+# frontends) can enable reasoning but do not send vLLM's top-level
+# `thinking_token_budget` request parameter.  Once the parser is correctly
+# keeping generated <think> text in reasoning, MiMo may spend the full
+# max_new_tokens budget in repetitive reasoning.  If
+# MIMO_DEFAULT_THINKING_TOKEN_BUDGET is set, apply it only when the client did
+# not provide an explicit budget.  This does not remove prior reasoning from
+# the prompt; it only forces the current generation to close </think>.
+python3 - <<'PY'
+from pathlib import Path
+path = Path('/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/chat_completion/serving.py')
+if not path.exists():
+    print('[fix-mimo-v2-vllm] chat completion serving.py not present; skipping default thinking budget patch')
+    raise SystemExit
+text = path.read_text()
+orig = text
+if 'import os\n' not in text.split('import time\n', 1)[0] + 'import time\n':
+    text = text.replace('import json\nimport time\n', 'import json\nimport os\nimport time\n', 1)
+old = '''            sampling_params: SamplingParams | BeamSearchParams
+            if request.use_beam_search:
+'''
+new = '''            default_thinking_token_budget = os.environ.get(
+                "MIMO_DEFAULT_THINKING_TOKEN_BUDGET", ""
+            )
+            if (
+                default_thinking_token_budget
+                and request.thinking_token_budget is None
+                and request.include_reasoning
+                and reasoning_parser is not None
+            ):
+                try:
+                    parsed_default_thinking_token_budget = int(
+                        default_thinking_token_budget
+                    )
+                except ValueError as exc:
+                    raise ValueError(
+                        "MIMO_DEFAULT_THINKING_TOKEN_BUDGET must be a "
+                        "non-negative integer"
+                    ) from exc
+                if parsed_default_thinking_token_budget < 0:
+                    raise ValueError(
+                        "MIMO_DEFAULT_THINKING_TOKEN_BUDGET must be a "
+                        "non-negative integer"
+                    )
+                request.thinking_token_budget = parsed_default_thinking_token_budget
+
+            sampling_params: SamplingParams | BeamSearchParams
+            if request.use_beam_search:
+'''
+if new not in text:
+    if old not in text:
+        raise SystemExit('[fix-mimo-v2-vllm] ERROR: serving.py sampling params anchor not found for thinking budget default')
+    text = text.replace(old, new, 1)
+if text != orig:
+    path.write_text(text)
+    print('[fix-mimo-v2-vllm] patched OpenAI chat serving default MiMo thinking budget')
+else:
+    print('[fix-mimo-v2-vllm] OpenAI chat serving default MiMo thinking budget already patched')
 PY
 
 # Some current vLLM builds have the MiMo V2 model class but not a HF config
@@ -546,6 +781,12 @@ find "$SITE_PACKAGES/vllm" -name __pycache__ -type d -prune -exec rm -rf {} + 2>
 python3 - <<'PY'
 import importlib.util
 assert importlib.util.find_spec('vllm.v1.attention.backends.triton_attn_diffkv'), 'TRITON_ATTN_DIFFKV not installed'
+from vllm.reasoning import ReasoningParserManager
+assert ReasoningParserManager.lazy_parsers.get('mimo') == (
+    'vllm.reasoning.mimo_reasoning_parser',
+    'MimoReasoningParser',
+), ReasoningParserManager.lazy_parsers.get('mimo')
+assert importlib.util.find_spec('vllm.reasoning.mimo_reasoning_parser'), 'MiMo reasoning parser not installed'
 from vllm.transformers_utils.config import _CONFIG_REGISTRY
 assert 'mimo_v2' in _CONFIG_REGISTRY, 'mimo_v2 config registry entry missing'
 from vllm.config.speculative import SpeculativeConfig

--- a/mods/fix-modelopt-mixed-mxfp8/run.sh
+++ b/mods/fix-modelopt-mixed-mxfp8/run.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+set -euo pipefail
+
+SITE_PACKAGES="/usr/local/lib/python3.12/dist-packages"
+MODELOPT="$SITE_PACKAGES/vllm/model_executor/layers/quantization/modelopt.py"
+
+cd "$SITE_PACKAGES"
+
+echo "[fix-modelopt-mixed-mxfp8] Patching ModelOpt mixed-precision MXFP8 dispatch"
+
+python3 - <<'PY'
+from pathlib import Path
+
+path = Path('/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/quantization/modelopt.py')
+text = path.read_text()
+orig = text
+
+# 1) ModelOpt MXFP8 checkpoints commonly name the E8M0 scale tensor
+#    weight_scale_inv, while ModelOptMxFp8LinearMethod expects weight_scale.
+#    Register a duplicate parameter alias so the existing checkpoint loader can
+#    populate the same tensor through either name.
+old = '''        layer.register_parameter("weight_scale", weight_scale)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        # Validate weight tensor
+'''
+new = '''        layer.register_parameter("weight_scale", weight_scale)
+        # ModelOpt MIXED_PRECISION checkpoints such as MiMo-V2.5-NVFP4 store
+        # MXFP8 microscale tensors as `.weight_scale_inv`.  The MXFP8 linear
+        # method consumes `layer.weight_scale`, so expose the same Parameter
+        # under both names.  `named_parameters(remove_duplicate=False)` used by
+        # vLLM loading will then find the checkpoint name and load into the
+        # tensor consumed by the MXFP8 kernel/emulation path.
+        if "weight_scale_inv" not in layer._parameters:
+            layer.register_parameter("weight_scale_inv", weight_scale)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        # Validate weight tensor
+'''
+if new not in text:
+    if old not in text:
+        raise SystemExit('[fix-modelopt-mixed-mxfp8] ERROR: MXFP8 weight_scale anchor not found')
+    text = text.replace(old, new, 1)
+else:
+    print('[fix-modelopt-mixed-mxfp8] weight_scale_inv alias already present')
+
+# 2) Add an MXFP8 sub-config to ModelOptMixedPrecisionConfig.
+old = '''        quantized_layers: dict[str, dict[str, Any]],
+        fp8_config: ModelOptFp8Config,
+        nvfp4_config: ModelOptNvFp4Config,
+    ) -> None:
+        super().__init__(exclude_modules)
+        self.kv_cache_quant_method = kv_cache_quant_method
+        self.quantized_layers = quantized_layers
+        self.fp8_config = fp8_config
+        self.nvfp4_config = nvfp4_config
+'''
+new = '''        quantized_layers: dict[str, dict[str, Any]],
+        fp8_config: ModelOptFp8Config,
+        mxfp8_config: ModelOptMxFp8Config,
+        nvfp4_config: ModelOptNvFp4Config,
+    ) -> None:
+        super().__init__(exclude_modules)
+        self.kv_cache_quant_method = kv_cache_quant_method
+        self.quantized_layers = quantized_layers
+        self.fp8_config = fp8_config
+        self.mxfp8_config = mxfp8_config
+        self.nvfp4_config = nvfp4_config
+'''
+if new not in text:
+    if old not in text:
+        raise SystemExit('[fix-modelopt-mixed-mxfp8] ERROR: mixed __init__ anchor not found')
+    text = text.replace(old, new, 1)
+else:
+    print('[fix-modelopt-mixed-mxfp8] mixed __init__ already patched')
+
+# 3) Construct that MXFP8 config in _from_config().
+old = '''        nvfp4_config = ModelOptNvFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            kv_cache_quant_algo=kv_cache_quant_method,
+            exclude_modules=[],
+            group_size=group_size,
+        )
+
+        return cls(
+            kv_cache_quant_method=kv_cache_quant_method,
+            exclude_modules=exclude_modules,
+            quantized_layers=quantized_layers,
+            fp8_config=fp8_config,
+            nvfp4_config=nvfp4_config,
+        )
+'''
+new = '''        mxfp8_config = ModelOptMxFp8Config(
+            is_checkpoint_mxfp8_serialized=True,
+            kv_cache_quant_algo=kv_cache_quant_method,
+            exclude_modules=[],
+        )
+        nvfp4_config = ModelOptNvFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            kv_cache_quant_algo=kv_cache_quant_method,
+            exclude_modules=[],
+            group_size=group_size,
+        )
+
+        return cls(
+            kv_cache_quant_method=kv_cache_quant_method,
+            exclude_modules=exclude_modules,
+            quantized_layers=quantized_layers,
+            fp8_config=fp8_config,
+            mxfp8_config=mxfp8_config,
+            nvfp4_config=nvfp4_config,
+        )
+'''
+if new not in text:
+    if old not in text:
+        raise SystemExit('[fix-modelopt-mixed-mxfp8] ERROR: mixed _from_config anchor not found')
+    text = text.replace(old, new, 1)
+else:
+    print('[fix-modelopt-mixed-mxfp8] mixed _from_config already patched')
+
+# 4) Dispatch MXFP8 LinearBase layers through ModelOptMxFp8LinearMethod.
+old = '''        if isinstance(layer, LinearBase):
+            if quant_algo == "FP8":
+                return ModelOptFp8LinearMethod(self.fp8_config)
+            if quant_algo == "NVFP4":
+                return ModelOptNvFp4LinearMethod(self.nvfp4_config)
+            # Layer not in quantized_layers — leave unquantized
+            return UnquantizedLinearMethod()
+'''
+new = '''        if isinstance(layer, LinearBase):
+            if quant_algo == "FP8":
+                return ModelOptFp8LinearMethod(self.fp8_config)
+            if quant_algo == "MXFP8":
+                return ModelOptMxFp8LinearMethod(self.mxfp8_config)
+            if quant_algo == "NVFP4":
+                return ModelOptNvFp4LinearMethod(self.nvfp4_config)
+            # Layer not in quantized_layers — leave unquantized
+            return UnquantizedLinearMethod()
+'''
+if new not in text:
+    if old not in text:
+        raise SystemExit('[fix-modelopt-mixed-mxfp8] ERROR: LinearBase dispatch anchor not found')
+    text = text.replace(old, new, 1)
+else:
+    print('[fix-modelopt-mixed-mxfp8] LinearBase MXFP8 dispatch already patched')
+
+# 5) Dispatch MXFP8 RoutedExperts as well for completeness.  MiMo-V2.5-NVFP4
+#    experts are NVFP4, but mixed ModelOpt can legitimately contain MXFP8 MoE.
+old = '''        if isinstance(layer, RoutedExperts):
+            if quant_algo == "FP8":
+                return ModelOptFp8MoEMethod(
+                    quant_config=self.fp8_config,
+                    moe_config=layer.moe_config,
+                )
+            if quant_algo == "NVFP4":
+                return ModelOptNvFp4FusedMoE(
+                    quant_config=self.nvfp4_config,
+                    moe_config=layer.moe_config,
+                )
+            return None
+'''
+new = '''        if isinstance(layer, RoutedExperts):
+            if quant_algo == "FP8":
+                return ModelOptFp8MoEMethod(
+                    quant_config=self.fp8_config,
+                    moe_config=layer.moe_config,
+                )
+            if quant_algo == "MXFP8":
+                return ModelOptMxFp8FusedMoE(
+                    quant_config=self.mxfp8_config,
+                    moe_config=layer.moe_config,
+                )
+            if quant_algo == "NVFP4":
+                return ModelOptNvFp4FusedMoE(
+                    quant_config=self.nvfp4_config,
+                    moe_config=layer.moe_config,
+                )
+            return None
+'''
+if new not in text:
+    if old not in text:
+        raise SystemExit('[fix-modelopt-mixed-mxfp8] ERROR: RoutedExperts dispatch anchor not found')
+    text = text.replace(old, new, 1)
+else:
+    print('[fix-modelopt-mixed-mxfp8] RoutedExperts MXFP8 dispatch already patched')
+
+if text != orig:
+    path.write_text(text)
+    print('[fix-modelopt-mixed-mxfp8] patched', path)
+else:
+    print('[fix-modelopt-mixed-mxfp8] no changes needed')
+PY
+
+# Clear stale bytecode for the patched module.
+find "$SITE_PACKAGES/vllm/model_executor/layers/quantization" -name __pycache__ -type d -prune -exec rm -rf {} + 2>/dev/null || true
+
+python3 -m py_compile "$MODELOPT"
+python3 - <<'PY'
+from vllm.model_executor.layers.quantization.modelopt import (
+    ModelOptMixedPrecisionConfig,
+    ModelOptMxFp8LinearMethod,
+)
+
+ql = {
+    "model.layers.0.self_attn.qkv_proj": {"quant_algo": "MXFP8", "group_size": 32},
+    "model.layers.1.mlp.experts.0.gate_proj": {"quant_algo": "NVFP4", "group_size": 16},
+}
+config = ModelOptMixedPrecisionConfig._from_config(
+    quant_method="MIXED_PRECISION",
+    kv_cache_quant_method=None,
+    exclude_modules=[],
+    original_config={"quantized_layers": ql},
+    group_size=None,
+)
+assert hasattr(config, "mxfp8_config")
+print("[fix-modelopt-mixed-mxfp8] validation OK: mixed config has MXFP8 dispatch support")
+print("[fix-modelopt-mixed-mxfp8] MXFP8 linear method:", ModelOptMxFp8LinearMethod)
+PY

--- a/recipes/mimo-v2.5-nvfp4.yaml
+++ b/recipes/mimo-v2.5-nvfp4.yaml
@@ -6,7 +6,12 @@
 # Applied from CyberTen's NVIDIA forum notes for MiMo V2.5 on GB10:
 #   - Ray V2 executor for cross-node stability.
 #   - MiMo parsers; never use qwen3 parser for MiMo reasoning/tool calls.
-#   - PR #42969 parser cleanup for streamed MiMo/Qwen3XML tool-call deltas.
+#   - Runtime MiMo reasoning prompt-state fix and fixed MiMo chat template:
+#     preserve real prior reasoning, avoid synthetic empty think blocks in
+#     history, prefill <think> for thinking-on turns, and soften tool/final
+#     answer transition instructions.
+#   - PR #42969 parser cleanup plus empty-delta hardening for streamed
+#     MiMo/Qwen3XML tool-call deltas.
 #   - PR #41797 / TRITON_ATTN_DIFFKV fallback for MiMoV2 DiffKV attention on
 #     sm_121a where FA3/FA4 is unavailable.
 #   - MTP-2 is enabled for speculative decoding; the runtime mod patches the
@@ -54,13 +59,16 @@ defaults:
   tensor_parallel: 2
   pipeline_parallel: 1
   gpu_memory_utilization: 0.86
-  max_model_len: 131072
+  max_model_len: 196608
   max_num_batched_tokens: 16384
+  max_num_seqs: 2
   # Default/server-wide generation cap. vLLM expects max_new_tokens here and
   # converts it to SamplingParams.max_tokens. Keep this comfortably below the
   # context window so long prompts still have room for output.
-  max_new_tokens: 8192
-
+  max_new_tokens: 16384
+  # Mild anti-looping pressure. Keep this conservative: high values can degrade
+  # exact XML/JSON tool-call formatting and short factual answers.
+  repetition_penalty: 1.05
 
 env:
   PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
@@ -77,18 +85,27 @@ env:
   VLLM_NVFP4_GEMM_BACKEND: flashinfer-cutlass
   VLLM_USE_FLASHINFER_MOE_FP4: "1"
   VLLM_FLASHINFER_MOE_BACKEND: throughput
+  # Server-side fallback for clients that enable MiMo reasoning but cannot send
+  # vLLM's top-level `thinking_token_budget` request parameter.  This preserves
+  # keep_all_reasoning history while forcing a </think> after the budget so an
+  # agent turn cannot spend the entire max_new_tokens window in reasoning.
+  # Raise, lower, or remove this recipe env value as needed.
+  MIMO_DEFAULT_THINKING_TOKEN_BUDGET: "4096"
 
 command: |
   vllm serve lukealonso/MiMo-V2.5-NVFP4 \
       --served-model-name {served_model_name} \
       --trust-remote-code \
       --dtype auto \
-      --kv-cache-dtype fp8_e4m3 \
+      --kv-cache-dtype bfloat16 \
       --block-size 64 \
       --attention-backend triton_attn_diffkv \
       --hf-overrides '{{"architectures":["MiMoV2OmniForCausalLM"]}}' \
+      --chat-template /workspace/mods/fix-mimo-v2-vllm/chat_template.jinja \
+      --default-chat-template-kwargs '{{"keep_all_reasoning":true}}' \
+      --reasoning-config '{{"reasoning_start_str": "<think>", "reasoning_end_str": "</think>"}}' \
       --generation-config vllm \
-      --override-generation-config '{{"temperature":1.0,"top_p":0.95,"max_new_tokens":{max_new_tokens}}}' \
+      --override-generation-config '{{"temperature":1.0,"top_p":0.95,"repetition_penalty":{repetition_penalty},"max_new_tokens":{max_new_tokens}}}' \
       --limit-mm-per-prompt '{{"image":4,"video":1,"audio":1}}' \
       --host {host} \
       --port {port} \
@@ -96,9 +113,9 @@ command: |
       --pipeline-parallel-size {pipeline_parallel} \
       --distributed-executor-backend ray \
       --speculative-config '{{"method":"mtp","num_speculative_tokens":2}}' \
-      --no-async-scheduling \
       --gpu-memory-utilization {gpu_memory_utilization} \
       --max-model-len {max_model_len} \
+      --max-num-seqs {max_num_seqs} \
       --max-num-batched-tokens {max_num_batched_tokens} \
       --enable-prefix-caching \
       --enable-chunked-prefill \

--- a/recipes/mimo-v2.5-nvfp4.yaml
+++ b/recipes/mimo-v2.5-nvfp4.yaml
@@ -6,6 +6,7 @@
 # Applied from CyberTen's NVIDIA forum notes for MiMo V2.5 on GB10:
 #   - Ray V2 executor for cross-node stability.
 #   - MiMo parsers; never use qwen3 parser for MiMo reasoning/tool calls.
+#   - PR #42969 parser cleanup for streamed MiMo/Qwen3XML tool-call deltas.
 #   - PR #41797 / TRITON_ATTN_DIFFKV fallback for MiMoV2 DiffKV attention on
 #     sm_121a where FA3/FA4 is unavailable.
 #   - MTP-2 is enabled for speculative decoding; the runtime mod patches the

--- a/recipes/mimo-v2.5-nvfp4.yaml
+++ b/recipes/mimo-v2.5-nvfp4.yaml
@@ -56,6 +56,10 @@ defaults:
   gpu_memory_utilization: 0.86
   max_model_len: 131072
   max_num_batched_tokens: 16384
+  # Default/server-wide generation cap. vLLM expects max_new_tokens here and
+  # converts it to SamplingParams.max_tokens. Keep this comfortably below the
+  # context window so long prompts still have room for output.
+  max_new_tokens: 8192
 
 
 env:
@@ -83,6 +87,8 @@ command: |
       --block-size 64 \
       --attention-backend triton_attn_diffkv \
       --hf-overrides '{{"architectures":["MiMoV2OmniForCausalLM"]}}' \
+      --generation-config vllm \
+      --override-generation-config '{{"temperature":1.0,"top_p":0.95,"max_new_tokens":{max_new_tokens}}}' \
       --limit-mm-per-prompt '{{"image":4,"video":1,"audio":1}}' \
       --host {host} \
       --port {port} \

--- a/recipes/mimo-v2.5-nvfp4.yaml
+++ b/recipes/mimo-v2.5-nvfp4.yaml
@@ -1,0 +1,101 @@
+# Recipe: MiMo-V2.5-NVFP4 on 2x DGX Spark / GB10
+#
+# Target model: https://huggingface.co/lukealonso/MiMo-V2.5-NVFP4
+# This is the NVFP4 expert-quantized export, not the Xiaomi FP8 checkpoint.
+#
+# Applied from CyberTen's NVIDIA forum notes for MiMo V2.5 on GB10:
+#   - Ray V2 executor for cross-node stability.
+#   - MiMo parsers; never use qwen3 parser for MiMo reasoning/tool calls.
+#   - PR #41797 / TRITON_ATTN_DIFFKV fallback for MiMoV2 DiffKV attention on
+#     sm_121a where FA3/FA4 is unavailable.
+#   - MTP-2 is enabled for speculative decoding; the runtime mod patches the
+#     MiMo-V2 MTP qkv loader for this NVFP4 checkpoint's deinterleaved layout
+#     and mirrors Omni-mapped MTP quant metadata back to draft model.mtp.* keys.
+#   - VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0 for GB10 cudagraph estimator
+#     overestimation.
+#   - soundfile + librosa are installed for vLLM audio input support.
+#   - Omni architecture is enabled with text/image/video/audio inputs.
+#
+# Current validated serving shape:
+#   - fp8_e4m3 KV cache is enabled; current metrics report
+#     calculate_kv_scales=False, so revisit KV scale calculation for stricter
+#     long-context quality studies.
+#   - Prefix caching and chunked prefill are enabled.
+#   - 131072 context has been brought up on 2x Spark; peak-context throughput
+#     benchmarking is still workload-sensitive, especially at concurrency > 1.
+
+recipe_version: "1"
+name: MiMo-V2.5-NVFP4-TP2-DGX-Spark
+description: >
+  vLLM serving lukealonso/MiMo-V2.5-NVFP4 (310B MoE, NVFP4 expert quant)
+  on a 2x DGX Spark / GB10 cluster with TP=2 via Ray.
+
+model: lukealonso/MiMo-V2.5-NVFP4
+container: vllm-node-mimo-v25-nvfp4
+cluster_only: true
+solo_only: false
+
+# Build a dedicated image so the MiMo DiffKV backend is present even when a
+# stock vllm-node image already exists locally.
+build_args:
+  - --apply-vllm-pr
+  - "41797"
+
+mods:
+  - mods/drop-caches
+  - mods/fix-mimo-v2-vllm
+  - mods/fix-modelopt-mixed-mxfp8
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  served_model_name: MiMo-V2.5-NVFP4
+  tensor_parallel: 2
+  pipeline_parallel: 1
+  gpu_memory_utilization: 0.86
+  max_model_len: 131072
+  max_num_batched_tokens: 16384
+
+
+env:
+  PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+  TORCH_CUDA_ARCH_LIST: "12.1a"
+  VLLM_USE_RAY_V2_EXECUTOR_BACKEND: "1"
+  VLLM_USE_RAY_COMPILED_DAG_OVERLAP_COMM: "1"
+  VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS: "0"
+  VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
+  NCCL_CUMEM_ENABLE: "0"
+  NCCL_NVLS_ENABLE: "0"
+  # NVFP4 / ModelOpt path. Keep the conservative FlashInfer-CUTLASS path by
+  # default. The experimental flashinfer-b12x MoE/GEMM path crashed the Spark
+  # cluster during bring-up and should only be retried in a small isolated test.
+  VLLM_NVFP4_GEMM_BACKEND: flashinfer-cutlass
+  VLLM_USE_FLASHINFER_MOE_FP4: "1"
+  VLLM_FLASHINFER_MOE_BACKEND: throughput
+
+command: |
+  vllm serve lukealonso/MiMo-V2.5-NVFP4 \
+      --served-model-name {served_model_name} \
+      --trust-remote-code \
+      --dtype auto \
+      --kv-cache-dtype fp8_e4m3 \
+      --block-size 64 \
+      --attention-backend triton_attn_diffkv \
+      --hf-overrides '{{"architectures":["MiMoV2OmniForCausalLM"]}}' \
+      --limit-mm-per-prompt '{{"image":4,"video":1,"audio":1}}' \
+      --host {host} \
+      --port {port} \
+      --tensor-parallel-size {tensor_parallel} \
+      --pipeline-parallel-size {pipeline_parallel} \
+      --distributed-executor-backend ray \
+      --speculative-config '{{"method":"mtp","num_speculative_tokens":2}}' \
+      --no-async-scheduling \
+      --gpu-memory-utilization {gpu_memory_utilization} \
+      --max-model-len {max_model_len} \
+      --max-num-batched-tokens {max_num_batched_tokens} \
+      --enable-prefix-caching \
+      --enable-chunked-prefill \
+      --load-format instanttensor \
+      --enable-auto-tool-choice \
+      --tool-call-parser mimo \
+      --reasoning-parser mimo


### PR DESCRIPTION
## Summary

Adds a reproducible MiMo-V2.5-NVFP4 recipe for 2× DGX Spark / GB10 and the runtime mods needed to run the NVFP4 export on vLLM.

Target model:

- `lukealonso/MiMo-V2.5-NVFP4`

Validated serving shape:

- TP=2 over Ray
- `instanttensor` load format
- ModelOpt mixed MXFP8/NVFP4
- FlashInfer-CUTLASS MXFP8 dense GEMM
- FlashInfer-CUTLASS NVFP4 MoE
- `TRITON_ATTN_DIFFKV`
- Omni architecture enabled
- MTP speculative decoding enabled (`num_speculative_tokens=2`)
- `fp8_e4m3` KV cache
- prefix caching + chunked prefill
- 131072 max model length

## Added files

- `recipes/mimo-v2.5-nvfp4.yaml`
- `mods/fix-mimo-v2-vllm/run.sh`
- `mods/fix-modelopt-mixed-mxfp8/run.sh`
- `docs/mimo-v25-nvfp4-dgx-spark.md`

## What the mods fix

### `fix-modelopt-mixed-mxfp8`

- Adds missing MXFP8 dispatch in `ModelOptMixedPrecisionConfig`.
- Adds an MXFP8 sub-config alongside FP8/NVFP4.
- Registers `weight_scale_inv` as an alias for MXFP8 scale metadata.
- Dispatches MXFP8 dense layers to `ModelOptMxFp8LinearMethod`.
- Adds MXFP8 routed-expert dispatch for completeness.

### `fix-mimo-v2-vllm`

- Adds local `MimoV2Config` registration when missing.
                                - Preserves explicit text-only architecture overrides for diagnostics.
- Filters multimodal/MTP tensors in text-only loading.                                - Fixes Omni vision merger bias mismatch.                                             - Skips target-model loading of MTP and audio-tokenizer tensors.
- Fixes fused-QKV TP loading for the NVFP4 checkpoint's `qkv-deinterleaved` layout by using `QKVParallelLinear.weight_loader` instead of blind row chunking.                - Applies the same QKV-aware loader to MTP layers.                                    - Adds Omni `packed_modules_mapping` for quant lookup of fused modules.
- Mirrors Omni-remapped MTP quant metadata back to draft `model.mtp.*` prefixes.      - Selects `MiMoV2OmniMTPModel` for Omni-capable MiMo configs whose raw architecture still says `MiMoV2ForCausalLM`.
## Validation
Expected startup markers:
```text                                                                               Resolved architecture: MiMoV2OmniForCausalLM                                          Resolved architecture: MiMoV2OmniMTPModelUsing FlashInferCutlassMxfp8LinearKernel for MXFP8 GEMM
Using 'FLASHINFER_CUTLASS' NvFp4 MoE backend
Using TRITON_ATTN_DIFFKV for attention
Using fp8_e4m3 data type to store kv cache
Chunked prefill is enabled with max_num_batched_tokens=16384
```

Functional validation performed:

- text completion
- chat/reasoning
- image input
- tool calling
- Omni MTP acceptance

Benchmark snapshot:

                                                                   - `tool-eval-bench`: 89/100, 123/138 points, no safety warnings
- MTP acceptance during tool eval: 15621 / 21221 = 73.61%

## Notes / limitations

                                                                - Image input has been validated; audio/video paths are exposed but still need full validation.
- `fp8_e4m3` KV cache is working, but current metrics report `calculate_kv_scales=False`.
- Throughput at high context and concurrency is workload-sensitive on 2× Spark; high-concurrency runs should be introduced carefully.