### PR TITLE
MTP recipe for qwen3.6-35B

### DIFF
--- a/recipes/qwen3.6-35b-a3b-fp8-mtp.yaml
+++ b/recipes/qwen3.6-35b-a3b-fp8-mtp.yaml
@@ -1,0 +1,50 @@
+# Recipe: Qwen/Qwen3.5-35B-A3B-FP8
+# Qwen/Qwen3.5-35B-A3B model in native FP8 format
+
+
+recipe_version: "1"
+name: Qwen36-35B-A3B
+description: vLLM serving Qwen3.6-35B-A3B-FP8
+
+# HuggingFace model to download (optional, for --download-model)
+model: Qwen/Qwen3.6-35B-A3B-FP8
+
+#solo_only: true
+
+# Container image to use
+container: vllm-node
+
+mods:
+  - mods/fix-qwen3.6-chat-template
+
+# Default settings (can be overridden via CLI)
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 2
+  gpu_memory_utilization: 0.7
+  max_model_len: 262144
+  max_num_batched_tokens: 16384
+
+# Environment variables
+env: 
+  VLLM_MARLIN_USE_ATOMIC_ADD: 1
+
+# The vLLM serve command template
+command: |
+  vllm serve Qwen/Qwen3.6-35B-A3B-FP8 \
+    --host {host} \
+    --port {port} \
+    --max-model-len {max_model_len} \
+    --max-num-batched-tokens {max_num_batched_tokens} \
+    --gpu-memory-utilization {gpu_memory_utilization} \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_xml \
+    --kv-cache-dtype fp8 \
+    --load-format fastsafetensors \
+    --attention-backend flashinfer \
+    --enable-prefix-caching \
+    --chat-template fixed_chat_template.jinja \
+    -tp {tensor_parallel} \
+    --distributed-executor-backend ray \
+    --speculative-config '{{"method": "mtp", "num_speculative_tokens": 3}}'


### PR DESCRIPTION
MTP recipe for qwen3.6-35B

# My test (dual DGX Spark cluster)
I've used `"num_speculative_tokens": 3` it has worked the best for me.

## vllm bench random

`docker exec vllm_node vllm bench serve     --host 192.168.200.3 --port 8000     --model Qwen/Qwen3.6-35B-A3B-FP8     --random-input-len 2048 --random-output-len 2000     --num-prompts 50 --request-rate 10 --temperature 0`

`============ Serving Benchmark Result ============
Successful requests:                     50        
Failed requests:                         0         
Request rate configured (RPS):           10.00     
Benchmark duration (s):                  137.22    
Total input tokens:                      102400    
Total generated tokens:                  100000    
Request throughput (req/s):              0.36      
Output token throughput (tok/s):         728.75    
Peak output token throughput (tok/s):    300.00    
Peak concurrent requests:                50.00     
Total token throughput (tok/s):          1474.99   
---------------Time to First Token----------------
Mean TTFT (ms):                          8798.63   
Median TTFT (ms):                        8995.54   
P99 TTFT (ms):                           11608.64  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          52.94     
Median TPOT (ms):                        52.37     
P99 TPOT (ms):                           62.11     
---------------Inter-token Latency----------------
Mean ITL (ms):                           188.79    
Median ITL (ms):                         186.03    
P99 ITL (ms):                            275.10    
---------------Speculative Decoding---------------
Acceptance rate (%):                     85.61     
Acceptance length:                       3.57      
Drafts:                                  28030     
Draft tokens:                            84090     
Accepted tokens:                         71993     
Per-position acceptance (%):
  Position 0:                            93.94     
  Position 1:                            85.63     
  Position 2:                            77.27     
==================================================`



## Share gpt dataset
`docker exec vllm_node vllm bench serve     --host 192.168.200.3 --port 8000     --model Qwen/Qwen3.6-35B-A3B-FP8     --dataset-name sharegpt --dataset-path /sharegpt.json     --num-prompts 50 --request-rate 10 --max-concurrency 16 --temperature 0`

`============ Serving Benchmark Result ============
Successful requests:                     50        
Failed requests:                         0         
Maximum request concurrency:             16        
Request rate configured (RPS):           10.00     
Benchmark duration (s):                  33.85     
Total input tokens:                      12852     
Total generated tokens:                  10581     
Request throughput (req/s):              1.48      
Output token throughput (tok/s):         312.61    
Peak output token throughput (tok/s):    143.00    
Peak concurrent requests:                20.00     
Total token throughput (tok/s):          692.32    
---------------Time to First Token----------------
Mean TTFT (ms):                          457.62    
Median TTFT (ms):                        388.35    
P99 TTFT (ms):                           1171.90   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          43.87     
Median TPOT (ms):                        41.30     
P99 TPOT (ms):                           89.68     
---------------Inter-token Latency----------------
Mean ITL (ms):                           118.52    
Median ITL (ms):                         113.07    
P99 ITL (ms):                            203.26    
---------------Speculative Decoding---------------
Acceptance rate (%):                     66.97     
Acceptance length:                       3.01      
Drafts:                                  3522      
Draft tokens:                            10566     
Accepted tokens:                         7076      
Per-position acceptance (%):
  Position 0:                            84.13     
  Position 1:                            65.64     
  Position 2:                            51.14     
==================================================`


Beats the non MTP model in both tests.

In "synthetic" test (random) beats dflash, but slightly slower with more realistic data (sharegpt)

With real life usecase - "build a web based todo app": fully autonomous agent - local claude code (https://github.com/csabakecskemeti/claude-autopilot-sandbox) the MTP recipe felt the fastest

