### PR TITLE
Install audio decode deps (soundfile, librosa, av) in runner image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -343,6 +343,17 @@ ENV PATH=$VLLM_BASE_DIR:$PATH
 RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
     uv pip install ray[default] fastsafetensors instanttensor
 
+# Audio modality support (iris senses).
+# vLLM is built from source above without the [audio] extra, so soundfile AND av
+# are both absent — every audio request 400s in load_audio ("Invalid or
+# unsupported audio file"), while image/video work (video uses the OpenCV loader
+# backend). soundfile (libsndfile) is vLLM's primary audio decode path; av
+# (PyAV/ffmpeg) is the fallback and also backs resample_audio_pyav; librosa
+# rounds out vLLM's `audio` extra. aarch64 binary wheels exist for all three.
+# Ref: iris plans/eval-harness.md v1.6.1 (senses modality × provider matrix).
+RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
+    uv pip install soundfile librosa av
+
 # Fix NCCL
 RUN rm /usr/local/lib/python3.12/dist-packages/nvidia/nccl/lib/libnccl.so.2 && \
     ln -s /usr/lib/aarch64-linux-gnu/libnccl.so.2 /usr/local/lib/python3.12/dist-packages/nvidia/nccl/lib/libnccl.so.2


### PR DESCRIPTION
### What
Adds `soundfile`, `librosa`, and `av` to the runner stage so the image can decode audio input.

### Why
vLLM is built from source here without the `[audio]` extra, so neither `soundfile` nor `av` (PyAV) end up in the runner image. As a result every audio request fails in vLLM's `load_audio` with `400 Invalid or unsupported audio file` — it tries `soundfile` first, falls back to `av`, and raises when both are missing. Image and video inputs are unaffected (video uses the OpenCV loader backend, which is already present), so the gap is audio-specific and easy to miss.

This matters for omni models like Nemotron-3-Nano-Omni, which advertise audio understanding but can't receive it without a decoder in the image.

### Change
One dedicated runner-stage layer:
- `soundfile` (libsndfile) — vLLM's primary audio decode path
- `av` (PyAV/ffmpeg) — fallback decoder; also backs `resample_audio_pyav`
- `librosa` — rounds out vLLM's `audio` extra (mel features)

Placed after the existing extra-deps layer so the flashinfer/vLLM wheel builds stay cache-hot — it's a runner-only rebuild. All three have `aarch64` binary wheels.

### Testing
Built and ran on a DGX Spark (GB10, SM_121, CUDA 13.0, aarch64). Before: audio requests 400'd in `load_audio`. After: Nemotron-3-Nano-Omni transcribes a WAV audio fixture correctly. Image/video unchanged.