### PR TITLE
Qwen3.6 35B Yarn extended context recipes

### DIFF
--- a/recipes/qwen3.6-35b-a3b-fp8-yarn-1m.yaml
+++ b/recipes/qwen3.6-35b-a3b-fp8-yarn-1m.yaml
@@ -48,6 +48,6 @@ command: |
     --attention-backend flashinfer \
     --enable-prefix-caching \
     --chat-template fixed_chat_template.jinja \
-    --hf-overrides '{{"rope_scaling":{{"rope_type":"yarn","factor":4.0,"original_max_position_embeddings":262144}}}}'
+    --hf-overrides '{{"rope_scaling":{{"rope_type":"yarn","factor":4.0,"original_max_position_embeddings":262144}}}}' \
     -tp {tensor_parallel} \
     --distributed-executor-backend ray

--- a/recipes/qwen3.6-35b-a3b-fp8-yarn-1m.yaml
+++ b/recipes/qwen3.6-35b-a3b-fp8-yarn-1m.yaml
@@ -1,0 +1,53 @@
+# Recipe: Qwen/Qwen3.6-35B-A3B-FP8 with YaRN scaling for 1M context
+# Extended context using YaRN RoPE interpolation (factor=4.0)
+# Native context: 262K → Extended: ~1M tokens
+#
+# WARNING: Higher scaling factors may degrade quality on shorter sequences.
+# Use for workloads that actually need very long context.
+
+recipe_version: "1"
+name: Qwen36-35B-A3B-YaRN-1M
+description: vLLM serving Qwen3.6-35B-A3B-FP8 with YaRN scaling for 1M context
+
+# HuggingFace model to download
+model: Qwen/Qwen3.6-35B-A3B-FP8
+
+# Container image to use
+container: vllm-node
+
+mods:
+  - mods/fix-qwen3.6-chat-template
+
+# Default settings
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 2
+  gpu_memory_utilization: 0.7
+  max_model_len: 1048576          # 4x native (~1M tokens)
+  max_num_batched_tokens: 4096    # Further reduced for 1M context memory
+
+# Environment variables
+env:
+  VLLM_MARLIN_USE_ATOMIC_ADD: 1
+  VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1  # Required for extended context
+
+# The vLLM serve command template
+# YaRN config: factor=4.0 extends 262K → ~1M
+command: |
+  vllm serve Qwen/Qwen3.6-35B-A3B-FP8 \
+    --host {host} \
+    --port {port} \
+    --max-model-len {max_model_len} \
+    --max-num-batched-tokens {max_num_batched_tokens} \
+    --gpu-memory-utilization {gpu_memory_utilization} \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_xml \
+    --kv-cache-dtype fp8 \
+    --load-format fastsafetensors \
+    --attention-backend flashinfer \
+    --enable-prefix-caching \
+    --chat-template fixed_chat_template.jinja \
+    --hf-overrides '{"rope_scaling":{"rope_type":"yarn","factor":4.0,"original_max_position_embeddings":262144}}' \
+    -tp {tensor_parallel} \
+    --distributed-executor-backend ray

--- a/recipes/qwen3.6-35b-a3b-fp8-yarn-1m.yaml
+++ b/recipes/qwen3.6-35b-a3b-fp8-yarn-1m.yaml
@@ -23,7 +23,7 @@ defaults:
   port: 8000
   host: 0.0.0.0
   tensor_parallel: 2
-  gpu_memory_utilization: 0.7
+  gpu_memory_utilization: 0.5
   max_model_len: 1048576          # 4x native (~1M tokens)
   max_num_batched_tokens: 4096    # Further reduced for 1M context memory
 

--- a/recipes/qwen3.6-35b-a3b-fp8-yarn-1m.yaml
+++ b/recipes/qwen3.6-35b-a3b-fp8-yarn-1m.yaml
@@ -48,6 +48,6 @@ command: |
     --attention-backend flashinfer \
     --enable-prefix-caching \
     --chat-template fixed_chat_template.jinja \
-    --hf-overrides '{"rope_scaling":{"rope_type":"yarn","factor":4.0,"original_max_position_embeddings":262144}}' \
+    --hf-overrides '{{"rope_scaling":{{"rope_type":"yarn","factor":4.0,"original_max_position_embeddings":262144}}}}'
     -tp {tensor_parallel} \
     --distributed-executor-backend ray

--- a/recipes/qwen3.6-35b-a3b-fp8-yarn-524k.yaml
+++ b/recipes/qwen3.6-35b-a3b-fp8-yarn-524k.yaml
@@ -20,7 +20,7 @@ defaults:
   port: 8000
   host: 0.0.0.0
   tensor_parallel: 2
-  gpu_memory_utilization: 0.7
+  gpu_memory_utilization: 0.6
   max_model_len: 524288           # 2x native (524K tokens)
   max_num_batched_tokens: 8192    # Reduced for memory with longer context
 

--- a/recipes/qwen3.6-35b-a3b-fp8-yarn-524k.yaml
+++ b/recipes/qwen3.6-35b-a3b-fp8-yarn-524k.yaml
@@ -1,0 +1,50 @@
+# Recipe: Qwen/Qwen3.6-35B-A3B-FP8 with YaRN scaling for 524K context
+# Extended context using YaRN RoPE interpolation (factor=2.0)
+# Native context: 262K → Extended: 524K
+
+recipe_version: "1"
+name: Qwen36-35B-A3B-YaRN-524K
+description: vLLM serving Qwen3.6-35B-A3B-FP8 with YaRN scaling for 524K context
+
+# HuggingFace model to download
+model: Qwen/Qwen3.6-35B-A3B-FP8
+
+# Container image to use
+container: vllm-node
+
+mods:
+  - mods/fix-qwen3.6-chat-template
+
+# Default settings
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 2
+  gpu_memory_utilization: 0.7
+  max_model_len: 524288           # 2x native (524K tokens)
+  max_num_batched_tokens: 8192    # Reduced for memory with longer context
+
+# Environment variables
+env:
+  VLLM_MARLIN_USE_ATOMIC_ADD: 1
+  VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1  # Required for extended context
+
+# The vLLM serve command template
+# YaRN config: factor=2.0 extends 262K → 524K
+command: |
+  vllm serve Qwen/Qwen3.6-35B-A3B-FP8 \
+    --host {host} \
+    --port {port} \
+    --max-model-len {max_model_len} \
+    --max-num-batched-tokens {max_num_batched_tokens} \
+    --gpu-memory-utilization {gpu_memory_utilization} \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_xml \
+    --kv-cache-dtype fp8 \
+    --load-format fastsafetensors \
+    --attention-backend flashinfer \
+    --enable-prefix-caching \
+    --chat-template fixed_chat_template.jinja \
+    --hf-overrides '{"rope_scaling":{"rope_type":"yarn","factor":2.0,"original_max_position_embeddings":262144}}' \
+    -tp {tensor_parallel} \
+    --distributed-executor-backend ray

--- a/recipes/qwen3.6-35b-a3b-fp8-yarn-524k.yaml
+++ b/recipes/qwen3.6-35b-a3b-fp8-yarn-524k.yaml
@@ -45,6 +45,6 @@ command: |
     --attention-backend flashinfer \
     --enable-prefix-caching \
     --chat-template fixed_chat_template.jinja \
-    --hf-overrides '{"rope_scaling":{"rope_type":"yarn","factor":2.0,"original_max_position_embeddings":262144}}' \
+    --hf-overrides '{{"rope_scaling":{{"rope_type":"yarn","factor":2.0,"original_max_position_embeddings":262144}}}}'
     -tp {tensor_parallel} \
     --distributed-executor-backend ray

--- a/recipes/qwen3.6-35b-a3b-fp8-yarn-524k.yaml
+++ b/recipes/qwen3.6-35b-a3b-fp8-yarn-524k.yaml
@@ -45,6 +45,6 @@ command: |
     --attention-backend flashinfer \
     --enable-prefix-caching \
     --chat-template fixed_chat_template.jinja \
-    --hf-overrides '{{"rope_scaling":{{"rope_type":"yarn","factor":2.0,"original_max_position_embeddings":262144}}}}'
+    --hf-overrides '{{"rope_scaling":{{"rope_type":"yarn","factor":2.0,"original_max_position_embeddings":262144}}}}' \
     -tp {tensor_parallel} \
     --distributed-executor-backend ray


### PR DESCRIPTION
Added YARN scaling to qwen3.6 to reach 524k and 1m context.
gpu_memory_utilization adjusted, without this in my test I found the headnode crashed while I've perforemet NIAH testing.
-----------------------------------------------------------------------------------------------------------------------
UPDATE: Occasionally I've experienced crashes even with this config on 1m ctx; 524k seems stable
-----------------------------------------------------------------------------------------------------------------------

My NIAH results
**original 250k ctx**

╟─────────────────────────╢
║       Context      Found     Accuracy       Time                   ║
╟──────────────────────────╢
║        49,998    16/20  ●●●●●●●●○○   80%   122.9s  ║
║       249,994    20/20  ●●●●●●●●●●  100%   162.1s  ║
║       499,995     0/20  ○○○○○○○○○○    0%    21.7s  ║
║       749,997     0/20  ○○○○○○○○○○    0%    31.0s  ║
║       999,996     0/20  ○○○○○○○○○○    0%    44.2s  ║
╟──────────────────────────╢


**500k ctx**

╟─────────────────────────╢
║       Context      Found     Accuracy       Time                   ║
╟──────────────────────────╢
║        49,998    11/20  ●●●●●○○○○○   55%   138.5s  ║
║       249,994    19/20  ●●●●●●●●●○   95%   180.7s  ║
║       499,995    20/20  ●●●●●●●●●●  100%   436.0s  ║
║       749,997     0/20  ○○○○○○○○○○    0%    34.1s     ║
║       999,996     0/20  ○○○○○○○○○○    0%    48.2s    ║
╟───────────────────────────╢

**1m ctx**
╟───────────────────────╢
║       Context      Found     Accuracy       Time           ║
╟───────────────────────╢
║        49,998    15/20  ●●●●●●●○○○   75%   118.1s  ║
║       249,998    20/20  ●●●●●●●●●●  100%   195.4s  ║
║       499,995    20/20  ●●●●●●●●●●  100%   443.0s  ║
║       749,997    14/20  ●●●●●●●○○○   70%   781.6s  ║
║       999,996    11/20  ●●●●●○○○○○   55%  1305.0s  ║
╟───────────────────────────╢
