### PR TITLE
feat: Step-3.7-Flash NVFP4 + MTP speculative decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,27 @@ Run:
 
 Please note that `--no-ray` is required for FP8 to fit with full context!
 
+##### NVFP4 + MTP (speculative decoding)
+
+The official NVFP4 export ships **no MTP (next-n predict) weights** — ModelOpt strips
+layers 45-47 and truncates several per-layer config lists during quantization — so the
+plain `step-3.7-flash-nvfp4` recipe runs without speculative decoding. To enable MTP-3
+on NVFP4, graft the BF16 MTP weights back into the cached checkpoint (one-time, ~5-7 GB
+download from the original `stepfun-ai/Step-3.7-Flash`). On **each** Spark in the cluster:
+
+```bash
+./hf-download.sh stepfun-ai/Step-3.7-Flash-NVFP4 -c
+./graft-step-3.7-mtp.sh      # idempotent: extracts + grafts MTP weights, extends config
+./run-recipe.sh step-3.7-flash-nvfp4-mtp
+```
+
+`graft-step-3.7-mtp.sh` adds the MTP weights (kept BF16); the `step-3.7-flash-nvfp4-mtp`
+recipe enables `--speculative-config method=mtp`; and the `step-3.7-flash` mod patches the
+drafter so its MTP block stays unquantized on NVFP4 (FP8 keeps its FP8 MTP unchanged —
+the draft model's quant config is filtered to target-model modules, so `exclude_modules`
+cannot reach these layers). Verified on dual DGX Spark (GB10): mean acceptance length
+~2.4-2.6 tokens/step.
+
 #### `use-official-vllm` NCCL Workaround
 
 Updated `mods/use-official-vllm` to also handle the NCCL load-order bug tracked in [vllm-project/vllm#42354](https://github.com/vllm-project/vllm/issues/42354). When both the pip-installed `nvidia/nccl/lib/libnccl.so.2` and system `libnccl2` are present, the mod redirects the pip-installed NCCL path to the system `/usr/lib` soname, matching the manual workaround that fixes multi-node DGX Spark hangs.

--- a/graft-step-3.7-mtp.sh
+++ b/graft-step-3.7-mtp.sh
@@ -32,8 +32,9 @@ fi
 # Resolve the snapshot referenced by refs/main (the current revision) so every
 # cluster node grafts the same one; fall back to the newest snapshot.
 REF_FILE="$REPO_DIR/refs/main"
-if [ -f "$REF_FILE" ] && [ -d "$REPO_DIR/snapshots/$(cat "$REF_FILE")" ]; then
-  SNAP_HOST="$REPO_DIR/snapshots/$(cat "$REF_FILE")/"
+REV="$([ -f "$REF_FILE" ] && cat "$REF_FILE" || true)"
+if [ -n "$REV" ] && [ -d "$REPO_DIR/snapshots/$REV" ]; then
+  SNAP_HOST="$REPO_DIR/snapshots/$REV/"
 else
   SNAP_HOST="$(ls -dt "$REPO_DIR"/snapshots/*/ 2>/dev/null | head -1)"
 fi

--- a/graft-step-3.7-mtp.sh
+++ b/graft-step-3.7-mtp.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# graft-step-3.7-mtp.sh
+#
+# Graft BF16 MTP (next-n predict) weights into the cached Step-3.7-Flash-NVFP4
+# checkpoint so MTP speculative decoding works. The official NVFP4 export ships
+# no MTP weights (ModelOpt strips layers 45-47 and truncates per-layer config
+# lists during quantization), so the step-3.7-flash-nvfp4-mtp recipe needs them
+# grafted back first.
+#
+# Usage (run on EACH Spark in the cluster, after downloading the model):
+#     ./hf-download.sh stepfun-ai/Step-3.7-Flash-NVFP4 -c
+#     ./graft-step-3.7-mtp.sh
+#     ./run-recipe.sh step-3.7-flash-nvfp4-mtp
+#
+# Idempotent (skips if already grafted). Extraction runs inside the vllm-node
+# container (needs torch + safetensors + huggingface_hub). Downloads ~5-7 GB
+# (one shard of the original stepfun-ai/Step-3.7-Flash) the first time.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HF_HOME="${HF_HOME:-$HOME/.cache/huggingface}"
+HUB="$HF_HOME/hub"
+IMAGE="${IMAGE:-vllm-node}"
+REPO_DIR="$HUB/models--stepfun-ai--Step-3.7-Flash-NVFP4"
+
+if [ ! -d "$REPO_DIR/snapshots" ]; then
+  echo "Error: Step-3.7-Flash-NVFP4 not found in HF cache."
+  echo "Run first: ./hf-download.sh stepfun-ai/Step-3.7-Flash-NVFP4 -c"
+  exit 1
+fi
+
+SNAP_HOST="$(ls -d "$REPO_DIR"/snapshots/*/ | head -1)"
+SNAP_NAME="$(basename "$SNAP_HOST")"
+SNAP_CTR="/root/.cache/huggingface/hub/models--stepfun-ai--Step-3.7-Flash-NVFP4/snapshots/$SNAP_NAME"
+
+echo "[graft] snapshot: $SNAP_HOST"
+echo "[graft] running extraction inside $IMAGE ..."
+docker run --rm --network host \
+  -v "$HF_HOME:/root/.cache/huggingface" \
+  -v "$SCRIPT_DIR/mods/step-3.7-flash:/mod:ro" \
+  --entrypoint python3 "$IMAGE" /mod/graft_mtp.py "$SNAP_CTR"
+
+echo "[graft] done. Serve with: ./run-recipe.sh step-3.7-flash-nvfp4-mtp"
+echo "[graft] (cluster: run this script on each Spark, or copy the snapshot's"
+echo "        model-mtp.safetensors + model.safetensors.index.json + config.json to peers.)"

--- a/graft-step-3.7-mtp.sh
+++ b/graft-step-3.7-mtp.sh
@@ -29,7 +29,17 @@ if [ ! -d "$REPO_DIR/snapshots" ]; then
   exit 1
 fi
 
-SNAP_HOST="$(ls -d "$REPO_DIR"/snapshots/*/ | head -1)"
+# Resolve the snapshot referenced by refs/main (the current revision) so every
+# cluster node grafts the same one; fall back to the newest snapshot.
+REF_FILE="$REPO_DIR/refs/main"
+if [ -f "$REF_FILE" ] && [ -d "$REPO_DIR/snapshots/$(cat "$REF_FILE")" ]; then
+  SNAP_HOST="$REPO_DIR/snapshots/$(cat "$REF_FILE")/"
+else
+  SNAP_HOST="$(ls -dt "$REPO_DIR"/snapshots/*/ 2>/dev/null | head -1)"
+fi
+if [ -z "${SNAP_HOST:-}" ] || [ ! -d "$SNAP_HOST" ]; then
+  echo "Error: no snapshot found under $REPO_DIR/snapshots"; exit 1
+fi
 SNAP_NAME="$(basename "$SNAP_HOST")"
 SNAP_CTR="/root/.cache/huggingface/hub/models--stepfun-ai--Step-3.7-Flash-NVFP4/snapshots/$SNAP_NAME"
 

--- a/mods/step-3.7-flash/graft_mtp.py
+++ b/mods/step-3.7-flash/graft_mtp.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Graft BF16 MTP (next-n predict) weights into a cached Step-3.7-Flash-NVFP4
+snapshot so MTP speculative decoding works.
+
+The official NVFP4 export ships no MTP weights (ModelOpt strips layers 45-47 and
+truncates several per-layer config lists during quantization). This script:
+  1. downloads the MTP shard from the original stepfun-ai/Step-3.7-Flash (BF16),
+  2. extracts the ~51 MTP tensors (layers >= num_hidden_layers) and writes them
+     into the snapshot as model-mtp.safetensors (kept BF16),
+  3. registers them in model.safetensors.index.json,
+  4. extends the truncated per-layer lists in config.json from the original.
+
+Idempotent (skips if MTP weights are already present). Run inside the vllm-node
+container (needs torch + safetensors + huggingface_hub). Arg: snapshot dir.
+"""
+import json, os, sys
+import torch
+from huggingface_hub import hf_hub_download
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+SNAP = sys.argv[1]
+ORIG_REPO = os.environ.get("STEP37_ORIG_REPO", "stepfun-ai/Step-3.7-Flash")
+MTP_FILE = "model-mtp.safetensors"
+
+
+def layer_of(key):
+    if ".layers." in key:
+        try:
+            return int(key.split(".layers.")[1].split(".")[0])
+        except Exception:
+            return -1
+    return -1
+
+
+def rewrite_json(name, obj):
+    """Replace a (possibly symlinked) file in the snapshot with a real edited copy,
+    so we never mutate the shared content-addressed blob."""
+    p = os.path.join(SNAP, name)
+    if os.path.islink(p) or os.path.exists(p):
+        os.remove(p)
+    json.dump(obj, open(p, "w"), indent=2)
+
+
+idx = json.load(open(os.path.join(SNAP, "model.safetensors.index.json")))
+wm = idx["weight_map"]
+if any(layer_of(k) >= 45 for k in wm):
+    print("[graft] MTP weights already present in snapshot; nothing to do")
+    sys.exit(0)
+
+# 1) locate + download the original MTP shard(s)
+o_idx_path = hf_hub_download(ORIG_REPO, "model.safetensors.index.json")
+o_wm = json.load(open(o_idx_path))["weight_map"]
+mtp_keys = sorted(k for k in o_wm if layer_of(k) >= 45)
+shards = sorted({o_wm[k] for k in mtp_keys})
+print("[graft] MTP keys=%d shards=%s -> downloading from %s" % (len(mtp_keys), shards, ORIG_REPO))
+
+tensors = {}
+for sh in shards:
+    shard_path = hf_hub_download(ORIG_REPO, sh)
+    with safe_open(shard_path, framework="pt") as f:
+        for k in mtp_keys:
+            if o_wm[k] == sh:
+                tensors[k] = f.get_tensor(k)  # BF16 in the original checkpoint
+
+# 2) write the MTP shard into the snapshot
+save_file(tensors, os.path.join(SNAP, MTP_FILE), metadata={"format": "pt"})
+
+# 3) register in the index
+nbytes = sum(t.numel() * t.element_size() for t in tensors.values())
+for k in mtp_keys:
+    wm[k] = MTP_FILE
+idx.setdefault("metadata", {})
+idx["metadata"]["total_size"] = idx["metadata"].get("total_size", 0) + nbytes
+rewrite_json("model.safetensors.index.json", idx)
+
+# 4) extend per-layer config lists (layer_types, partial_rotary_factors, swiglu_*) to cover MTP layers
+o_cfg = json.load(open(hf_hub_download(ORIG_REPO, "config.json")))
+cfg = json.load(open(os.path.join(SNAP, "config.json")))
+
+
+def extend_lists(node, onode):
+    if not (isinstance(node, dict) and isinstance(onode, dict)):
+        return
+    for k, v in list(node.items()):
+        ov = onode.get(k)
+        if isinstance(v, list) and isinstance(ov, list) and len(ov) > len(v):
+            node[k] = v + ov[len(v):]
+        elif isinstance(v, dict) and isinstance(ov, dict):
+            extend_lists(v, ov)
+
+
+extend_lists(cfg, o_cfg)
+rewrite_json("config.json", cfg)
+print("[graft] grafted %d MTP tensors (%.2f GB), extended config lists -> %s"
+      % (len(tensors), nbytes / 1e9, SNAP))

--- a/mods/step-3.7-flash/graft_mtp.py
+++ b/mods/step-3.7-flash/graft_mtp.py
@@ -2,16 +2,19 @@
 """Graft BF16 MTP (next-n predict) weights into a cached Step-3.7-Flash-NVFP4
 snapshot so MTP speculative decoding works.
 
-The official NVFP4 export ships no MTP weights (ModelOpt strips layers 45-47 and
-truncates several per-layer config lists during quantization). This script:
-  1. downloads the MTP shard from the original stepfun-ai/Step-3.7-Flash (BF16),
-  2. extracts the ~51 MTP tensors (layers >= num_hidden_layers) and writes them
+The official NVFP4 export ships no MTP weights (ModelOpt strips the next-n
+predict layers -- those at index >= num_hidden_layers -- and truncates several
+per-layer config lists during quantization). This script:
+  1. downloads the MTP shard(s) from the original stepfun-ai/Step-3.7-Flash (BF16),
+  2. extracts the MTP tensors (layer index >= num_hidden_layers) and writes them
      into the snapshot as model-mtp.safetensors (kept BF16),
   3. registers them in model.safetensors.index.json,
   4. extends the truncated per-layer lists in config.json from the original.
 
 Idempotent (skips if MTP weights are already present). Run inside the vllm-node
-container (needs torch + safetensors + huggingface_hub). Arg: snapshot dir.
+container (needs torch + safetensors + huggingface_hub).
+
+Usage: graft_mtp.py <nvfp4-snapshot-dir>
 """
 import json, os, sys
 import torch
@@ -19,41 +22,62 @@ from huggingface_hub import hf_hub_download
 from safetensors import safe_open
 from safetensors.torch import save_file
 
+if len(sys.argv) < 2:
+    sys.exit("usage: graft_mtp.py <nvfp4-snapshot-dir>")
 SNAP = sys.argv[1]
 ORIG_REPO = os.environ.get("STEP37_ORIG_REPO", "stepfun-ai/Step-3.7-Flash")
 MTP_FILE = "model-mtp.safetensors"
+
+
+def load_json(path):
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def write_json_into_snapshot(name, obj):
+    """Replace a (possibly symlinked) file in the snapshot with a real edited copy,
+    so we never mutate the shared content-addressed blob."""
+    p = os.path.join(SNAP, name)
+    if os.path.islink(p) or os.path.exists(p):
+        os.remove(p)
+    with open(p, "w", encoding="utf-8") as f:
+        json.dump(obj, f, indent=2)
+
+
+def num_hidden_layers(cfg):
+    for node in (cfg, cfg.get("text_config", {}) if isinstance(cfg, dict) else {}):
+        if isinstance(node, dict) and "num_hidden_layers" in node:
+            return int(node["num_hidden_layers"])
+    raise ValueError("num_hidden_layers not found in config.json")
 
 
 def layer_of(key):
     if ".layers." in key:
         try:
             return int(key.split(".layers.")[1].split(".")[0])
-        except Exception:
+        except ValueError:
             return -1
     return -1
 
 
-def rewrite_json(name, obj):
-    """Replace a (possibly symlinked) file in the snapshot with a real edited copy,
-    so we never mutate the shared content-addressed blob."""
-    p = os.path.join(SNAP, name)
-    if os.path.islink(p) or os.path.exists(p):
-        os.remove(p)
-    json.dump(obj, open(p, "w"), indent=2)
+# MTP layers are those at index >= num_hidden_layers (the next-n predict blocks).
+cfg = load_json(os.path.join(SNAP, "config.json"))
+cutoff = num_hidden_layers(cfg)
 
-
-idx = json.load(open(os.path.join(SNAP, "model.safetensors.index.json")))
+idx = load_json(os.path.join(SNAP, "model.safetensors.index.json"))
 wm = idx["weight_map"]
-if any(layer_of(k) >= 45 for k in wm):
+if any(layer_of(k) >= cutoff for k in wm):
     print("[graft] MTP weights already present in snapshot; nothing to do")
     sys.exit(0)
 
 # 1) locate + download the original MTP shard(s)
-o_idx_path = hf_hub_download(ORIG_REPO, "model.safetensors.index.json")
-o_wm = json.load(open(o_idx_path))["weight_map"]
-mtp_keys = sorted(k for k in o_wm if layer_of(k) >= 45)
+o_wm = load_json(hf_hub_download(ORIG_REPO, "model.safetensors.index.json"))["weight_map"]
+mtp_keys = sorted(k for k in o_wm if layer_of(k) >= cutoff)
+if not mtp_keys:
+    sys.exit("[graft] no MTP tensors (layer >= %d) found in %s" % (cutoff, ORIG_REPO))
 shards = sorted({o_wm[k] for k in mtp_keys})
-print("[graft] MTP keys=%d shards=%s -> downloading from %s" % (len(mtp_keys), shards, ORIG_REPO))
+print("[graft] cutoff=%d  MTP keys=%d  shards=%s  (from %s)"
+      % (cutoff, len(mtp_keys), shards, ORIG_REPO))
 
 tensors = {}
 for sh in shards:
@@ -72,11 +96,10 @@ for k in mtp_keys:
     wm[k] = MTP_FILE
 idx.setdefault("metadata", {})
 idx["metadata"]["total_size"] = idx["metadata"].get("total_size", 0) + nbytes
-rewrite_json("model.safetensors.index.json", idx)
+write_json_into_snapshot("model.safetensors.index.json", idx)
 
-# 4) extend per-layer config lists (layer_types, partial_rotary_factors, swiglu_*) to cover MTP layers
-o_cfg = json.load(open(hf_hub_download(ORIG_REPO, "config.json")))
-cfg = json.load(open(os.path.join(SNAP, "config.json")))
+# 4) extend truncated per-layer config lists from the original config
+o_cfg = load_json(hf_hub_download(ORIG_REPO, "config.json"))
 
 
 def extend_lists(node, onode):
@@ -91,6 +114,6 @@ def extend_lists(node, onode):
 
 
 extend_lists(cfg, o_cfg)
-rewrite_json("config.json", cfg)
+write_json_into_snapshot("config.json", cfg)
 print("[graft] grafted %d MTP tensors (%.2f GB), extended config lists -> %s"
       % (len(tensors), nbytes / 1e9, SNAP))

--- a/mods/step-3.7-flash/graft_mtp.py
+++ b/mods/step-3.7-flash/graft_mtp.py
@@ -17,7 +17,6 @@ container (needs torch + safetensors + huggingface_hub).
 Usage: graft_mtp.py <nvfp4-snapshot-dir>
 """
 import json, os, sys
-import torch
 from huggingface_hub import hf_hub_download
 from safetensors import safe_open
 from safetensors.torch import save_file
@@ -45,7 +44,10 @@ def write_json_into_snapshot(name, obj):
 
 
 def num_hidden_layers(cfg):
-    for node in (cfg, cfg.get("text_config", {}) if isinstance(cfg, dict) else {}):
+    # Prefer the language-model sub-config (this is a multimodal config); the MTP
+    # layers live in the LM, so its num_hidden_layers is the right cutoff.
+    tc = cfg.get("text_config", {}) if isinstance(cfg, dict) else {}
+    for node in (tc, cfg):
         if isinstance(node, dict) and "num_hidden_layers" in node:
             return int(node["num_hidden_layers"])
     raise ValueError("num_hidden_layers not found in config.json")

--- a/mods/step-3.7-flash/step-3.7-support.patch
+++ b/mods/step-3.7-flash/step-3.7-support.patch
@@ -955,3 +955,30 @@ index d51bf22..1c608ef 100644
                  self.drafter.set_per_group_block_table(
                      kv_cache_gid, cm.block_table_tensor
                  )
+diff --git a/vllm/model_executor/models/step3p5_mtp.py b/vllm/model_executor/models/step3p5_mtp.py
+--- a/vllm/model_executor/models/step3p5_mtp.py
++++ b/vllm/model_executor/models/step3p5_mtp.py
+@@ -52,9 +52,21 @@
+         self.enorm = GemmaRMSNorm(config.hidden_size, config.rms_norm_eps)
+         self.hnorm = GemmaRMSNorm(config.hidden_size, config.rms_norm_eps)
+         self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
+-        self.shared_head = SharedHead(config=config, quant_config=quant_config)
++        # NVFP4 checkpoints ship no MTP (next-n predict) weights; when grafted back
++        # they are BF16, so the MTP block must stay unquantized. FP8 checkpoints ship
++        # FP8 MTP weights and keep their quant config. (vLLM filters the draft model's
++        # quant config to target-model modules, so hf_quant_config exclude_modules
++        # cannot reach these layers -- hence the explicit override here.)
++        import copy as _copy
++        _mtp_unquant = quant_config is not None and "NvFp4" in type(quant_config).__name__
++        _vc = _copy.copy(vllm_config)
++        if _mtp_unquant:
++            _vc.quant_config = None
++        self.shared_head = SharedHead(
++            config=config, quant_config=(None if _mtp_unquant else quant_config)
++        )
+         self.mtp_block = Step3p5DecoderLayer(
+-            vllm_config,
++            _vc,
+             prefix=f"{prefix}.mtp_block",
+         )
+ 

--- a/mods/step-3.7-flash/step-3.7-support.patch
+++ b/mods/step-3.7-flash/step-3.7-support.patch
@@ -975,7 +975,7 @@ diff --git a/vllm/model_executor/models/step3p5_mtp.py b/vllm/model_executor/mod
 +            try:
 +                _qname = str(quant_config.get_name())
 +            except Exception:
-+                _qname = type(quant_config).__name__
++                _qname = ""
 +        _mtp_unquant = "fp4" in _qname.lower()
 +        _vc = _copy.copy(vllm_config)
 +        if _mtp_unquant:

--- a/mods/step-3.7-flash/step-3.7-support.patch
+++ b/mods/step-3.7-flash/step-3.7-support.patch
@@ -958,18 +958,25 @@ index d51bf22..1c608ef 100644
 diff --git a/vllm/model_executor/models/step3p5_mtp.py b/vllm/model_executor/models/step3p5_mtp.py
 --- a/vllm/model_executor/models/step3p5_mtp.py
 +++ b/vllm/model_executor/models/step3p5_mtp.py
-@@ -52,9 +52,21 @@
+@@ -52,9 +52,28 @@
          self.enorm = GemmaRMSNorm(config.hidden_size, config.rms_norm_eps)
          self.hnorm = GemmaRMSNorm(config.hidden_size, config.rms_norm_eps)
          self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
 -        self.shared_head = SharedHead(config=config, quant_config=quant_config)
 +        # NVFP4 checkpoints ship no MTP (next-n predict) weights; when grafted back
 +        # they are BF16, so the MTP block must stay unquantized. FP8 checkpoints ship
-+        # FP8 MTP weights and keep their quant config. (vLLM filters the draft model's
-+        # quant config to target-model modules, so hf_quant_config exclude_modules
-+        # cannot reach these layers -- hence the explicit override here.)
++        # FP8 MTP weights and keep their quant config. We detect NVFP4 via the stable
++        # quant-config name (e.g. "modelopt_fp4") rather than a class name. (vLLM
++        # filters the draft model's quant config to target-model modules, so
++        # hf_quant_config exclude_modules cannot reach these layers.)
 +        import copy as _copy
-+        _mtp_unquant = quant_config is not None and "NvFp4" in type(quant_config).__name__
++        _qname = ""
++        if quant_config is not None:
++            try:
++                _qname = str(quant_config.get_name())
++            except Exception:
++                _qname = type(quant_config).__name__
++        _mtp_unquant = "fp4" in _qname.lower()
 +        _vc = _copy.copy(vllm_config)
 +        if _mtp_unquant:
 +            _vc.quant_config = None

--- a/recipes/step-3.7-flash-nvfp4-mtp.yaml
+++ b/recipes/step-3.7-flash-nvfp4-mtp.yaml
@@ -1,0 +1,48 @@
+# Recipe: Step-3.7-Flash-NVFP4 + MTP (speculative decoding)
+# Same as step-3.7-flash-nvfp4, but with MTP-3 speculative decoding enabled.
+#
+# IMPORTANT: the official NVFP4 export ships NO MTP (next-n predict) weights, so
+# they must be grafted into the cached checkpoint first. On EACH Spark in the
+# cluster, run:
+#     ./hf-download.sh stepfun-ai/Step-3.7-Flash-NVFP4 -c
+#     ./graft-step-3.7-mtp.sh
+# then:
+#     ./run-recipe.sh step-3.7-flash-nvfp4-mtp
+# See README -> "Step-3.7-Flash NVFP4 + MTP".
+
+recipe_version: "1"
+name: Step-3.7-Flash-NVFP4-MTP
+description: vLLM serving Step-3.7-Flash-NVFP4 with MTP speculative decoding on two Sparks
+
+model: stepfun-ai/Step-3.7-Flash-NVFP4
+container: vllm-node
+cluster_only: true
+
+mods:
+  - mods/step-3.7-flash
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 2
+  gpu_memory_utilization: 0.75   # MTP draft + speculative token slots need headroom; lower if OOM
+  max_model_len: 262144
+  num_speculative_tokens: 3      # Step-3.7-Flash has 3 MTP heads (MTP-3)
+
+env: {}
+
+# {{ }} escape literal braces for str.format(); {num_speculative_tokens} is templated.
+command: |
+  vllm serve stepfun-ai/Step-3.7-Flash-NVFP4 \
+      --trust-remote-code \
+      --port {port} \
+      --host {host} \
+      --gpu-memory-utilization {gpu_memory_utilization} \
+      -tp {tensor_parallel} \
+      --distributed-executor-backend ray \
+      --max-model-len {max_model_len} \
+      --enable-auto-tool-choice \
+      --reasoning-parser step3p5 \
+      --tool-call-parser step3p5 \
+      --speculative-config '{{"method": "mtp", "num_speculative_tokens": {num_speculative_tokens}}}' \
+      --load-format instanttensor


### PR DESCRIPTION
## Summary

Adds an opt-in path to run **Step-3.7-Flash-NVFP4 with MTP-3 speculative decoding** on a DGX Spark cluster. Today the `step-3.7-flash-nvfp4` recipe can't use MTP because the official NVFP4 export ships **no MTP weights**; this PR grafts them back, repairs the per-layer config, and keeps the drafter's MTP block unquantized so it loads.

Verified on **dual DGX Spark (GB10 / sm_121a), TP=2**: mean acceptance length **~2.4–2.6 tokens/step** (per-position ~0.80 / 0.44 / 0.14).

## Why it's needed

ModelOpt's NVFP4 quantization of Step-3.7-Flash breaks MTP in two ways:

1. **The 3 MTP (next-n predict) layers are dropped** — the checkpoint has no tensors for layers `45–47`, even though `config.json` still declares `num_nextn_predict_layers: 3`.
2. **4 per-layer config lists are truncated** to `num_hidden_layers` (45): `layer_types`, `partial_rotary_factors`, `swiglu_limits`, `swiglu_limits_shared` — so the drafter `IndexError`s while building the MTP layers.

And separately, even with the MTP weights present (BF16), vLLM's MTP drafter builds its `mtp_block` with the NVFP4 quant config and can't be told to keep it unquantized: the draft model's quant config is filtered to *target*-model modules, so `hf_quant_config` `exclude_modules` can't reach the MTP layers → shape mismatch (`param=(11264, 2048)` NVFP4-packed vs `loaded=(11264, 4096)` BF16).

## What's in this PR

| File | Purpose |
|------|---------|
| `graft-step-3.7-mtp.sh` + `mods/step-3.7-flash/graft_mtp.py` | Idempotently graft the BF16 MTP tensors from `stepfun-ai/Step-3.7-Flash` into the cached NVFP4 snapshot (one ~5–7 GB shard) and extend the truncated config lists. Extraction runs inside the `vllm-node` container. |
| `recipes/step-3.7-flash-nvfp4-mtp.yaml` | `step-3.7-flash-nvfp4` + `--speculative-config '{"method":"mtp","num_speculative_tokens":3}'`. |
| `mods/step-3.7-flash/step-3.7-support.patch` | Keep the drafter's `mtp_block` + `shared_head` **unquantized on NVFP4** (matching the BF16 graft); detected via the stable `quant_config.get_name()`. NVFP4-only — FP8 keeps its FP8 MTP unchanged. |
| `README.md` | NVFP4 + MTP section. |

## Usage

On each Spark in the cluster:

```bash
./hf-download.sh stepfun-ai/Step-3.7-Flash-NVFP4 -c
./graft-step-3.7-mtp.sh
./run-recipe.sh step-3.7-flash-nvfp4-mtp
```

The plain `step-3.7-flash-nvfp4` recipe keeps working unchanged (the extra MTP weights are simply unused without `--speculative-config`).

## Upstream root causes (this PR is the interim Spark workaround)

- **vLLM** — the drafter quantizes the MTP block on NVFP4 and can't keep unquantized MTP weights (the patch here works around it): vllm-project/vllm#44087
- **stepfun** — the `Step-3.7-Flash-NVFP4` export is missing the MTP weights and has truncated config lists (the graft script here works around it): https://github.com/stepfun-ai/Step-3.7-Flash/issues/3

A corrected NVFP4 export would remove the graft step; a vLLM-side fix would remove the patch.

## Notes

- `git apply --check` passes for the updated patch; the recipe command renders correctly via `str.format()`.
- `num_speculative_tokens=3` measured fastest for single-stream (vs 2 and 1) on this hardware — the MTP draft passes are cheap relative to the 200B+ target.
- I served via a custom launcher (non-HF-cache model paths) rather than `run-recipe.py` end-to-end, so please sanity-check the `run-recipe.py` HF-cache integration in your environment.
