### PR TITLE
Drop cu130 index and switch to PyPi PyTorch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN apt update && \
 
 # Additional deps
 RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
-     uv pip install torch==2.11.0 torchvision torchaudio triton --index-url https://download.pytorch.org/whl/cu130 && \
+     uv pip install torch==2.11.0 torchvision torchaudio triton && \
      uv pip install nvidia-nvshmem-cu13 "apache-tvm-ffi<0.2" filelock pynvml requests tqdm
 
 # Configure Ccache for CUDA/C++
@@ -794,7 +794,7 @@ ARG PRE_TRANSFORMERS=0
 
 # Install deps
 RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
-     uv pip install torch==2.11.0 torchvision torchaudio triton --index-url https://download.pytorch.org/whl/cu130 && \
+     uv pip install torch==2.11.0 torchvision torchaudio triton && \
      uv pip install nvidia-nvshmem-cu13 "apache-tvm-ffi<0.2"
 
 # Install wheels from host ./wheels/ (bind-mounted from build context — no layer bloat)
@@ -803,8 +803,14 @@ RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
 # prometheus-fastapi-instrumentator route name lookup.
 RUN --mount=type=bind,source=wheels,target=/workspace/wheels \
     --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
-    PINNED_TORCH=$(python3 -c "import torch; print(torch.__version__)") && \
+    PINNED_TORCH=$(python3 -c "import torch; print(torch.__version__.split('+')[0])") && \
     echo "torch==${PINNED_TORCH}" > /tmp/wheel-override.txt && \
+    echo "nvidia-cuda-nvcc==13.0.*" >> /tmp/wheel-override.txt && \
+    echo "cuda-bindings==13.0.*" >> /tmp/wheel-override.txt && \
+    echo "nvidia-cuda-cccl==13.0.*" >> /tmp/wheel-override.txt && \
+    echo "nvidia-cuda-crt==13.0.*" >> /tmp/wheel-override.txt && \
+    echo "nvidia-nvvm==13.0.*" >> /tmp/wheel-override.txt && \
+    echo "cuda-python==13.0.*" >> /tmp/wheel-override.txt && \
     echo "fastapi[standard]>=0.115.0,<0.137.0" >> /tmp/wheel-override.txt && \
     if [ "$PRE_TRANSFORMERS" = "1" ]; then \
         echo "transformers>=5.0.0" >> /tmp/wheel-override.txt; \
@@ -824,12 +830,10 @@ ENV PATH=$VLLM_BASE_DIR:$PATH
 # Final extra deps
 # Pin torch via --override so transitive deps (e.g. instanttensor) can't trigger
 # a re-resolve that swaps the CUDA-built torch for PyPI's CPU wheel.
-RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
-    PINNED_TORCH=$(python3 -c "import torch; print(torch.__version__)") && \
-    echo "torch==${PINNED_TORCH}" > /tmp/torch-override.txt && \
-    echo "fastapi[standard]>=0.115.0,<0.137.0" >> /tmp/torch-override.txt && \
+RUN --mount=type=bind,source=wheels,target=/workspace/wheels \
+    --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
     uv pip install ray[default] fastsafetensors instanttensor \
-        --override /tmp/torch-override.txt
+        --override /tmp/wheel-override.txt
 
 # Fix NCCL
 RUN rm /usr/local/lib/python3.12/dist-packages/nvidia/nccl/lib/libnccl.so.2 && \


### PR DESCRIPTION
Since PyTorch version 2.11, `--index-url https://download.pytorch.org/whl/cu130` is not necessary anymore to get cu130 builds, as the standard PyTorch has `cu130` included. However, those packages from PyPi don't have `+cu130` endings, so a `uv pip list` shows `torch==2.11.0` instead of `torch==2.11.0+cu130`. However, `torch.__version__` still yields `2.11.0+cu130`, so builds will fail. Therefore, I "relaxed" the version checking a little bit (which it completely fine for PyTorch >= 2.11 because it includes cu130 anyway).

<s>There is however a catch: I did not yet remove `--index-url https://download.pytorch.org/whl/cu130`, because there seems to be a difference with the PyPi version of `torch` and the one provided by that index: around 51 TPS for `qwen/Qwen3.6-35B-A3B-FP8` instad of around 54-55 TPS. Also, upgrading from PyTorch 2.11 to PyTorch 2.12 seems to degrade performance to around 52 TPS, both for the PyPi-version as well as for the version on the index.</s>

For PyTorch 2.12 I've rebuild `flashinfer` and `vllm` from scratch, since otherwise the `build-and-copy.sh` will fail.

I'll benchmark the PyPi PyTorch version against the one on the PyTorch cu130 index a little bit further and maybe file a bug report. But other than that, this PR will insure that future PyTorch versions can simply be enabled by changing a version number.

Alternatively, this can be considered such a minor performance regression that PyTorch 2.12 from PyPi still gets enabled, then I can modify my PR accordingly.