### PR TITLE
fix: add --init to docker run for automatic zombie reaping

### DIFF
--- a/launch-cluster.sh
+++ b/launch-cluster.sh
@@ -854,7 +854,7 @@ start_cluster() {
         docker_entrypoint_args="--entrypoint="
     fi
 
-    local docker_args_common="--gpus all -d --rm --network host --name $CONTAINER_NAME $docker_entrypoint_args $DOCKER_ARGS $IMAGE_NAME"
+    local docker_args_common="--init --gpus all -d --rm --network host --name $CONTAINER_NAME $docker_entrypoint_args $DOCKER_ARGS $IMAGE_NAME"
     local docker_caps_args=""
     local docker_resource_args=""
 


### PR DESCRIPTION
## Problem

When Ray worker processes crash inside the container during sustained TP operation, Docker's default PID 1 (the entrypoint process) does not reap orphaned child processes. Over time, defunct Ray workers accumulate as zombies:

- Consuming process table entries
- Leaking shared memory (`psm_*` segments in `/dev/shm/`)
- One observed zombie (`ray::RayWorkerP`) was spinning at 384% CPU for 69+ hours

After ~22 hours of sustained TP=2 operation on DGX Spark, zombie accumulation causes `shm_broadcast` timeouts between tensor-parallel workers, which cascades into Ray GCS failure and `EngineDeadError`.

## Fix

Add `--init` to the `docker run` command in `launch-cluster.sh`. This installs `tini` as PID 1 inside the container, which automatically reaps zombie child processes when they exit.

`tini` is pre-installed in NVIDIA's official Docker images — no build changes required.

## Change

One line in `launch-cluster.sh`:
```diff
-local docker_args_common="--gpus all -d --rm ...
+local docker_args_common="--init --gpus all -d --rm ...
```

## Observed Environment
- NVIDIA DGX Spark (GB10)
- Model: Step-3.7-Flash-NVFP4 (TP=2)
- Symptom: `EngineDeadError` after ~22h uptime, `RayWorkerP` defunct at 384% CPU
- 12 zombie processes accumulated from prior crash cycles

## Testing
- `--init` is compatible with `--privileged`, `--ipc=host`, and `--gpus all`
- No functional change to container behavior — only adds PID 1 reaping