### PR TITLE
Add recipe for deepseek-ai/DeepSeek-V4-Flash on 2x DGX Spark (GB10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,68 @@ The default CUDA base image was changed to `nvidia/cuda:13.0.2-devel-ubuntu24.04
 
 The Dockerfile also now passes `--allow-change-held-packages` when installing the custom NCCL Debian packages, avoiding apt failures when replacing held CUDA/NCCL packages during image builds.
 
+#### DeepSeek-V4-Flash on 2x DGX Spark (GB10 / sm_121)
+
+Added `deepseek-v4-flash-jasl-gb10`, a recipe for serving [`deepseek-ai/DeepSeek-V4-Flash`](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash) on a two-node GB10 cluster, tracking [vllm-project/vllm#41834](https://github.com/vllm-project/vllm/pull/41834) (jasl's SM12x DSv4 work).
+
+DeepSeek-V4-Flash does not run on consumer Blackwell (sm_120/121) with stock vLLM: its config sets `swiglu_limit=10.0`, and the only NVFP4 MoE backend that honors the SwiGLU clamp (`FLASHINFER_TRTLLM`) requires sm_100 family. The sparse-attention indexer additionally needs DeepGEMM kernels that do not exist for sm_120/121. The [jasl/vllm `codex/ds4-sm120-min-enable`](https://github.com/jasl/vllm/tree/codex/ds4-sm120-min-enable) branch addresses both: Triton replacements for the sparse-MLA / FP8 indexer paths, MegaMoE that externalises the SwiGLU clamp via runtime `activation_clamp`, and SM121-tuned kernels with a custom NCCL build that avoids the DGX Spark NCCL load-order hang.
+
+This recipe is **not** compatible with the stock `vllm-node` image. Build the bespoke image first, per [jasl/vllm-ds4-sm120-harness `docker/gb10-pr`](https://github.com/jasl/vllm-ds4-sm120-harness/tree/main/docker/gb10-pr):
+
+```bash
+git clone https://github.com/jasl/vllm-ds4-sm120-harness.git
+cd vllm-ds4-sm120-harness/docker/gb10-pr
+docker build --progress=plain -t ds4-vllm-gb10:pr --build-arg BUILD_JOBS=8 .
+```
+
+The build runs on a GB10 host and takes 25-40 minutes. Distribute the image to the second Spark via `docker save | ssh ... docker load` (or your preferred path).
+
+Download the model:
+
+```bash
+./hf-download.sh deepseek-ai/DeepSeek-V4-Flash -c
+```
+
+Run:
+
+```bash
+./run-recipe.sh deepseek-v4-flash-jasl-gb10
+```
+
+The recipe sets `--distributed-executor-backend ray` (jasl's own GB10 README uses `mp`, which only works for single-node multi-GPU; our two-node single-GPU-per-node cluster needs `ray`). `--enable-expert-parallel` engages MegaMoE and is required.
+
+Per jasl's HANDOFF.md, GB10 acceptance is currently no-thinking with the 128K long-context gate; treat `think-high` as exploratory.
+
+##### Performance settings baked into the recipe
+
+Validated on a 2x DGX Spark (GB10) cluster, ISL 1024 / OSL 256, 32 prompts per run via `vllm bench serve`:
+
+| Setting | Result |
+| --- | --- |
+| `max_num_seqs: 4` (raised from `2`) | +45% aggregate tok/s at C≥4 (real concurrency was the cap, not the GPU) |
+| `--enable-prefix-caching` | safe default for repeated-prefix workloads |
+| `--enable-flashinfer-autotune` | minor steady-state win |
+| `--served-model-name deepseek-v4-flash deepseek-ai/DeepSeek-V4-Flash` | zero-downtime model-swap alias trick from `tonyd2wild/deepseek-v4-flash-dgx-spark` |
+| `--speculative-config '{"method":"mtp","num_speculative_tokens":2}'` | +25% single-stream decode tok/s. MTP works fine on GB10 in this build despite jasl's `HANDOFF.md` caveat (~50% acceptance on random tokens; up to ~78% reported by `tonyd2wild` on structured/code) |
+| `VLLM_USE_FLASHINFER_MOE_FP8=1` + `VLLM_FLASHINFER_ALLREDUCE_BACKEND=trtllm` | additional +3-4% at C≥4. Will be replaced by `--moe-backend` flag in vLLM v0.23 |
+| `gpu_memory_utilization: 0.80` | matches the new upstream default (eugr 2026-06-09 bump). KV pool ~17 GiB/rank, 1.7M-token cluster pool, ~6.4× concurrency at 256K. Host stays at ~11 GB available throughout. |
+| `max_model_len: 262144` (raised from `131072`) | 256K per-request context (jasl's tested gate is 128K). KV math at the new pool size gives ~6.4× concurrency headroom at 256K — fits comfortably with `max_num_seqs: 4`. |
+
+Combined: **+28% C=1, +56% C=4, +60% C=8** vs the all-defaults launch (jasl's baseline GB10 README command without these tunings).
+
+###### Higher-concurrency variant (for shared multi-user endpoints)
+
+If your workload is 6-10 concurrent users instead of 1-4, raise both:
+
+- `gpu_memory_utilization: 0.85`
+- `max_num_seqs: 8`
+
+That config measured **+131% aggregate tok/s at C=8** (37 → 86 tok/s, TTFT collapse 37 s → 1.3 s) at the cost of ~10% loss at C=4 and tighter host memory margin (10 GB vs 11 GB available). Not the default because most setups will see better numbers at C=1-4 with `max_num_seqs: 4`.
+
+###### Knobs we tried that did NOT work on this image
+
+`--kernel-config linear_backend=flashinfer_cutlass` / `flashinfer_trtllm` (both reject DSv4's ScaledMM — `flashinfer_cutlass` needs DeepGEMM which isn't installed; `flashinfer_trtllm` has no kernel implementation for this layer type), `VLLM_USE_B12X_MOE=1` (env var ignored; the b12x MoE backend isn't selectable for DSv4's `deepseek_v4_fp8` quant path — that env var appears to be specific to `aidendle94/sparkrun-vllm-ds4-gb10:production-ready`).
+
 ### 2026-06-06
 
 #### MiniMax Multi-Node Regression Workaround

--- a/recipes/deepseek-v4-flash-jasl-gb10.yaml
+++ b/recipes/deepseek-v4-flash-jasl-gb10.yaml
@@ -1,0 +1,85 @@
+# Recipe: DeepSeek-V4-Flash on 2x DGX Spark (GB10 / sm_121)
+# Uses the ds4-vllm-gb10:pr image built from jasl/vllm-ds4-sm120-harness; see README
+# for build instructions. Tracks vllm-project/vllm#41834.
+
+recipe_version: "1"
+name: DeepSeek-V4-Flash-jasl-GB10
+description: vLLM serving deepseek-ai/DeepSeek-V4-Flash on two GB10 DGX Sparks (jasl PR branch image)
+
+# HuggingFace model to download (optional, for --download-model)
+model: deepseek-ai/DeepSeek-V4-Flash
+
+# Custom GB10-only image. Build from:
+#   https://github.com/jasl/vllm-ds4-sm120-harness/tree/main/docker/gb10-pr
+container: ds4-vllm-gb10:pr
+
+# Can only be run in a cluster (TP=2 across two GB10 nodes)
+cluster_only: true
+
+# No mods — the image is already a DSv4-tuned vLLM build.
+mods: []
+
+# Default settings (can be overridden via CLI).
+# - max_num_seqs 4 unlocks real concurrency (raising from 2 was ~+45% aggregate
+#   tok/s at C>=4 in our benchmarks). For high-concurrency workloads (6-10 users),
+#   bump to 8 and raise gpu_memory_utilization to 0.85 to fit the KV.
+# - max_model_len 262144 (256K) — jasl validates 131072 (128K) as the GB10 gate;
+#   we extend to 256K because the KV math at gpu_memory_utilization 0.80 gives
+#   us 6.4x concurrency headroom at 256K (verified via vLLM's startup report).
+# - gpu_memory_utilization 0.80 matches the new upstream default (eugr
+#   2026-06-09 bump). KV pool ~17 GiB/rank, ~1.7M-token cluster pool; KV usage
+#   peaked at ~41% under our stress runs, host had ~11 GB margin throughout.
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 2
+  gpu_memory_utilization: 0.80
+  max_model_len: 262144
+  max_num_seqs: 4
+  max_num_batched_tokens: 4176
+
+env:
+  # SERVE_USE_FP4_INDEXER_CACHE=0 is required on sm_12x: the FP4 indexer cache
+  # path requires the sm_100-only DeepGEMM kernel. See jasl HANDOFF.md.
+  SERVE_USE_FP4_INDEXER_CACHE: "0"
+  # Route the FP8 dense linear ops through flashinfer kernels (small ~3-4%
+  # aggregate throughput win in our benchmarks). Will be replaced by
+  # `--moe-backend` flag in vLLM v0.23.
+  VLLM_USE_FLASHINFER_MOE_FP8: "1"
+  # Use TRT-LLM's cross-rank allreduce.
+  VLLM_FLASHINFER_ALLREDUCE_BACKEND: "trtllm"
+
+# The vLLM serve command template.
+# `--enable-expert-parallel` engages MegaMoE, which is required: it externalises
+# the SwiGLU clamp via runtime activation_clamp, bypassing the NVFP4 oracle's
+# clamp-set rejection (only FLASHINFER_TRTLLM is in NVFP4_BACKENDS_WITH_CLAMP,
+# and FLASHINFER_TRTLLM requires sm_100 family).
+# jasl's GB10 README uses `--distributed-executor-backend mp`; that only works
+# for single-node multi-GPU. For 1 GPU per Spark we use `ray`.
+# MTP speculative decoding (num_speculative_tokens=2) gave ~+25% single-stream
+# decode in our benchmarks; tonyd2wild reports ~78% draft acceptance on code/
+# structured output (we measured ~50% on random tokens — content-dependent).
+command: |
+  vllm serve deepseek-ai/DeepSeek-V4-Flash \
+      --host {host} --port {port} \
+      --trust-remote-code \
+      --tensor-parallel-size {tensor_parallel} \
+      --distributed-executor-backend ray \
+      --max-model-len {max_model_len} \
+      --max-num-seqs {max_num_seqs} \
+      --max-num-batched-tokens {max_num_batched_tokens} \
+      --gpu-memory-utilization {gpu_memory_utilization} \
+      --kv-cache-dtype fp8 \
+      --block-size 256 \
+      --enable-expert-parallel \
+      --enable-prefix-caching \
+      --enable-flashinfer-autotune \
+      --speculative-config '{{"method":"mtp","num_speculative_tokens":2}}' \
+      --served-model-name deepseek-v4-flash deepseek-ai/DeepSeek-V4-Flash \
+      --tokenizer-mode deepseek_v4 \
+      --tool-call-parser deepseek_v4 \
+      --enable-auto-tool-choice \
+      --reasoning-parser deepseek_v4 \
+      --reasoning-config '{{"reasoning_parser":"deepseek_v4","reasoning_start_str":"<think>","reasoning_end_str":"</think>"}}' \
+      --default-chat-template-kwargs '{{"thinking":true}}' \
+      --compilation-config '{{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}}'


### PR DESCRIPTION
Adds `deepseek-v4-flash-jasl-gb10`, a recipe for serving [`deepseek-ai/DeepSeek-V4-Flash`](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash) on a two-node GB10 / sm_121 DGX Spark cluster, plus a CHANGELOG entry under `2026-06-07` with image-build instructions.

## Why a separate recipe

DeepSeek-V4-Flash will not run on consumer spark clones with the stock `vllm-node` image:

1. The model config sets `swiglu_limit=10.0`. vLLM's NVFP4 oracle requires the selected backend to honor that clamp; the only backend in `NVFP4_BACKENDS_WITH_CLAMP` is `FLASHINFER_TRTLLM`, and the trtllm-gen NVFP4 MoE kernel rejects sm_120/121 (it requires Blackwell datacenter family 100).
2. The DeepSeek-V4 sparse-attention indexer hardcodes DeepGEMM calls (`fp8_fp4_mqa_logits` / `fp8_fp4_paged_mqa_logits`). DeepGEMM has no sm_120/121 kernels (issue [deepseek-ai/DeepGEMM#324](https://github.com/deepseek-ai/DeepGEMM/issues/324) is still open).

The recipe therefore depends on jasl's [`codex/ds4-sm120-min-enable`](https://github.com/jasl/vllm/tree/codex/ds4-sm120-min-enable) branch tracked by [vllm-project/vllm#41834](https://github.com/vllm-project/vllm/pull/41834), which:

- adds Triton replacements for the sparse-MLA / FP8 indexer paths (DeepGEMM-free on sm_12x);
- routes MoE through MegaMoE, which externalises the SwiGLU clamp via a runtime `activation_clamp=` parameter and so sidesteps the NVFP4 oracle's clamp-set rejection;
- pins NCCL `v2.30u1` built with `-gencode=arch=compute_121` and symlinks the system libnccl over the python wheel to fix the DGX Spark NCCL load-order hang.

A bespoke image (`ds4-vllm-gb10:pr`) is built from [`jasl/vllm-ds4-sm120-harness/docker/gb10-pr`](https://github.com/jasl/vllm-ds4-sm120-harness/tree/main/docker/gb10-pr); the recipe `container:` field points at that tag. The README CHANGELOG entry walks through the build.

## Notable flag choices

- **`--distributed-executor-backend ray`** — jasl's own GB10 README uses `mp`, but `mp` requires all TP ranks on a single node (their dev host is a single workstation with 2 GPUs). Two single-GPU GB10 Sparks need Ray for cross-node TP.
- **`--enable-expert-parallel`** — required to engage MegaMoE. Without it, the FusedMoE oracle hits the SwiGLU-clamp dead end on the standard path.
- **`SERVE_USE_FP4_INDEXER_CACHE=0`** in `env:` — the FP4 indexer cache path still routes through DeepGEMM (sm_100 only); the FP8 path goes through jasl's Triton fallback.
- **`--max-model-len 262144`** — upped to 256k after a bit of testing, 128K is jasl's current GB10 long-context acceptance gate
- **`--gpu-memory-utilization 0.80`** — upped from 0.70 from the jasl configuration

## Test results

- `./run-recipe.py deepseek-v4-flash-jasl-gb10 --dry-run -n "10.0.0.1,10.0.0.2"` parses and renders the expected launch script (including the JSON `--compilation-config` after `{{...}}` escaping).
- `./tests/test_recipes.sh` shows 46 pass / 3 fail — the same baseline as upstream main (3 unrelated pre-existing README/recipe mismatches in `minimax-m2-awq`, `glm-4.7-flash-awq`, and `openai-gpt-oss-120b`). No new failures introduced.
- End-to-end serving on a real 2x DGX Spark cluster: `Application startup complete` in 280 s; `/v1/chat/completions` returns coherent output (verified with simple smoke prompts). Server fingerprint: `vllm-0.1.dev17437+gad75ac7a8.d20260607-tp2-ep-...` confirming jasl's commit `ad75ac7a8`, TP=2, EP engaged.

## Notes

- The recipe will be obsolete when vllm-project/vllm#41834 merges into upstream `main`. At that point a stock `vllm-node` image rebuild would carry the SM12x DSv4 path and the recipe could be retargeted to `container: vllm-node`.
- jasl's HANDOFF.md flags GB10 acceptance as "no-thinking, no-MTP only" today; treat `think-high` and MTP as exploratory on GB10.

## AI assistance disclosure

This recipe and PR description were prepared with Claude (Anthropic) assistance. All flag choices, image-build instructions, and end-to-end serving were validated on real DGX Spark hardware before submission.