### PR TITLE
Allow configurable docker network (assists firewalling)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,9 @@ MASTER_PORT="29501"
 # Note: This is a configuration variable, NOT passed as env var to container
 CONTAINER_NAME="vllm_node"
 
+# NETWORK: Docker network to use (default: host)
+# NETWORK="host"
+
 # Container environment variables
 # Any variable starting with CONTAINER_ (except CONTAINER_NAME) will be converted to -e flags
 # Example: CONTAINER_NCCL_DEBUG=INFO becomes -e NCCL_DEBUG=INFO

--- a/launch-cluster.sh
+++ b/launch-cluster.sh
@@ -21,6 +21,7 @@ MASTER_PORT="29501"
 # Initialize variables
 NODES_ARG=""
 CONTAINER_NAME="$DEFAULT_CONTAINER_NAME"
+NETWORK="host"
 COMMAND_TO_RUN=""
 DAEMON_MODE="false"
 CHECK_CONFIG="false"
@@ -48,7 +49,7 @@ PORT_MAPPINGS=()
 
 # Function to print usage
 usage() {
-    echo "Usage: $0 [-n <node_ips>] [-t <image_name>] [--name <container_name>] [--eth-if <if_name>] [--ib-if <if_name>] [--nccl-debug <level>] [--check-config] [--solo] [-p <host:container>] [-d] [action] [command]"
+    echo "Usage: $0 [-n <node_ips>] [-t <image_name>] [--name <container_name>] [--eth-if <if_name>] [--ib-if <if_name>] [--nccl-debug <level>] [--check-config] [--solo] [-p <host:container>] [--network <name>] [-d] [action] [command]"
     echo "  -n, --nodes     Comma-separated list of node IPs (Optional, auto-detected if omitted)"
     echo "  -t              Docker image name (Optional, default: $IMAGE_NAME)"
     echo "  --name          Container name (Optional, default: $DEFAULT_CONTAINER_NAME)"
@@ -63,6 +64,7 @@ usage() {
     echo "  --solo          Solo mode: skip autodetection, launch only on current node, do not launch Ray cluster"
     echo "  --master-port   Port for cluster coordination: Ray head port or PyTorch distributed master port (default: 29501)"
     echo "  -p, --publish   Publish a container port in Docker format (e.g. -p 8000:8000). Solo mode only; can be specified multiple times."
+    echo "  --network       Container network (default: host). Useful with -p to use a custom network instead of bridge."
     echo "  --no-ray        No-Ray mode: run multi-node vLLM without Ray (uses PyTorch distributed backend)"
     echo "  --no-cache-dirs Do not mount default cache directories (~/.cache/vllm, ~/.cache/flashinfer, ~/.triton)"
     echo "  --keep-entrypoint Keep the Docker image entrypoint instead of clearing it by default"
@@ -84,6 +86,7 @@ usage() {
     echo "  MASTER_PORT         Port for cluster coordination (default: 29501)"
     echo "  CONTAINER_NAME      Container name (default: vllm_node)"
     echo "  LOCAL_IP            Local IP address (for solo mode or override auto-detection)"
+    echo "  NETWORK             Container network (default: host)"
     echo "  CONTAINER_*         Any variable starting with CONTAINER_ (except CONTAINER_NAME)"
     echo "                      becomes -e flag. Example: CONTAINER_NCCL_DEBUG=INFO -> -e NCCL_DEBUG=INFO"
     echo ""
@@ -94,6 +97,7 @@ usage() {
     echo "  MASTER_PORT=29501"
     echo "  CONTAINER_NAME=vllm_node"
     echo "  LOCAL_IP=192.168.1.1"
+    echo "  NETWORK=ai-network"
     echo "  CONTAINER_NCCL_DEBUG=INFO"
     echo "  CONTAINER_HF_TOKEN=abc123"
     echo ""
@@ -140,6 +144,7 @@ while [[ "$#" -gt 0 ]]; do
         -h|--help) usage ;;
         --config) CONFIG_FILE="$2"; shift ;;
         --setup|--discover) FORCE_DISCOVER=true; export FORCE_DISCOVER ;;
+        --network) NETWORK="$2"; shift ;;
         start|stop|status) 
             if [[ -n "$LAUNCH_SCRIPT_PATH" ]]; then
                 echo "Error: Action '$1' is not compatible with --launch-script. Please omit the action or not use --launch-script."
@@ -272,6 +277,11 @@ fi
 
 if [[ -n "$DOTENV_LOCAL_IP" ]]; then
     export LOCAL_IP="$DOTENV_LOCAL_IP"
+fi
+
+# Apply NETWORK from .env (CLI --network takes precedence)
+if [[ "$NETWORK" == "host" ]] && [[ -n "$DOTENV_NETWORK" ]]; then
+    NETWORK="$DOTENV_NETWORK"
 fi
 
 # Validate non-privileged mode flags
@@ -535,10 +545,12 @@ if [[ "$CHECK_CONFIG" == "true" ]]; then
     echo "  ETH Interface: $ETH_IF"
     echo "  IB Interface: $IB_IF"
     echo "  Docker Args: $DOCKER_ARGS"
-    if [[ ${#PORT_MAPPINGS[@]} -gt 0 ]]; then
-        echo "  Docker Network: default bridge with published ports: ${PORT_MAPPINGS[*]}"
+    if [[ ${#PORT_MAPPINGS[@]} -eq 0 ]]; then
+        echo "  Docker Network: $NETWORK"
+    elif [[ "$NETWORK" == "host" ]]; then
+        echo "  Docker Network: default bridge with published ports: ${PORT_MAPPINGS[*]} (--network host overridden)"
     else
-        echo "  Docker Network: host"
+        echo "  Docker Network: $NETWORK with published ports: ${PORT_MAPPINGS[*]}"
     fi
     if [[ "$MOUNT_CACHE_DIRS" == "true" ]]; then
          echo "  Mounting Cache Dirs: ${CACHE_DIRS_TO_CREATE[*]}"
@@ -868,9 +880,11 @@ start_cluster() {
         docker_entrypoint_args="--entrypoint="
     fi
 
-    local docker_network_args="--network host"
+    local docker_network_args="--network $NETWORK"
     if [[ ${#PORT_MAPPINGS[@]} -gt 0 ]]; then
-        docker_network_args=""
+        if [[ "$NETWORK" == "host" ]]; then
+            docker_network_args=""
+        fi
         for mapping in "${PORT_MAPPINGS[@]}"; do
             docker_network_args="$docker_network_args -p $mapping"
         done

--- a/run-recipe.py
+++ b/run-recipe.py
@@ -853,6 +853,20 @@ Examples:
         help="Shared memory size in GB (only with --non-privileged, default: 64)",
     )
 
+    launch_group.add_argument(
+        "--network",
+        dest="docker_network",
+        help="Docker network to use (default: host). Useful with --publish.",
+    )
+    launch_group.add_argument(
+        "-p", "--publish",
+        action="append",
+        dest="publish_ports",
+        default=[],
+        metavar="HOST:CONTAINER",
+        help="Publish a container port (can be specified multiple times). Solo mode only.",
+    )
+
     # Config file option
     parser.add_argument(
         "--config",
@@ -972,6 +986,15 @@ Examples:
                 eth_if = env["ETH_IF"]
             if not ib_if and env.get("IB_IF"):
                 ib_if = env["IB_IF"]
+
+
+
+    # Resolve docker network: CLI > .env (works for both solo and cluster)
+    docker_network = args.docker_network or None
+    if not docker_network:
+        env_net = load_env_file().get("NETWORK")
+        if env_net:
+            docker_network = env_net
 
     worker_nodes = get_worker_nodes(nodes) if nodes else []
     is_cluster = len(nodes) > 1
@@ -1241,6 +1264,10 @@ Examples:
             cmd_parts.extend(["--shm-size-gb", str(args.shm_size_gb)])
         if args.config_file:
             cmd_parts.extend(["--config", args.config_file])
+        if docker_network:
+            cmd_parts.extend(["--network", docker_network])
+        for port in getattr(args, "publish_ports", []):
+            cmd_parts.extend(["-p", port])
         cmd_parts.extend(["\\", "\n      --launch-script", "/tmp/tmpXXXXXX.sh"])
         print(" ".join(cmd_parts))
         print()
@@ -1313,6 +1340,10 @@ Examples:
 
         if args.config_file:
             cmd.extend(["--config", args.config_file])
+        if docker_network:
+            cmd.extend(["--network", docker_network])
+        for port in getattr(args, "publish_ports", []):
+            cmd.extend(["-p", port])
 
         # Add launch script
         cmd.extend(["--launch-script", temp_script])

--- a/tests/test_recipes.sh
+++ b/tests/test_recipes.sh
@@ -386,6 +386,13 @@ test_launch_cluster_help() {
         log_fail "--help does not document --publish"
         log_verbose "$output"
     fi
+
+    if echo "$output" | grep -q -- "--network"; then
+        log_pass "--help documents --network"
+    else
+        log_fail "--help does not document --network"
+        log_verbose "$output"
+    fi
 }
 
 # Test: launch-cluster.sh references examples/ not profiles/


### PR DESCRIPTION
This leaves the default of `--network host` but allows override.  Being restricted to `--network host` makes certain firewall setups difficult/impossible, if one wanted to setup their host as DMZ accessible to the wider internet.

For example, allowing non-`host` networking and using a port serving argument like `-p 127.0.0.1:7000:8000` along with the following `/etc/nftables.conf` firewall setup can allow setups where only SSH-forwarded ports are allowed to connect to the vLLM instance:
```
table inet docker_lockdown {
  chain preraw {
    #must run AFTER Docker DNAT (which is priority -100)
    type filter hook prerouting priority -50;

    # If traffic was DNATed (i.e. on a Docker-published port),
    # and destination is NOT loopback (i.e. it was pointed to us from outside), drop it
    ct status dnat ip daddr != 127.0.0.0/8 drop
    ct status dnat ip6 daddr != ::1 drop
  }
}
```
