### PR TITLE
Add DeepSeek-V4-Flash recipe (aidendle94 B12X image) + /workspace fix for third-party images

### DIFF
--- a/launch-cluster.sh
+++ b/launch-cluster.sh
@@ -798,6 +798,9 @@ make_node_script() {
 copy_script_to_container() {
     local container="$1"; local script_path="$2"; local label="${3:-node}"
     echo "Copying launch script to $label..."
+    # Ensure /workspace exists: the repo's own image has it, but third-party vLLM images
+    # (e.g. custom community builds) may not. mkdir -p is a no-op when it already exists.
+    docker exec "$container" mkdir -p /workspace || { echo "Error: could not create /workspace in $label"; exit 1; }
     docker cp "$script_path" "$container:/workspace/exec-script.sh" || { echo "Error: docker cp to $label failed"; exit 1; }
     docker exec "$container" chmod +x /workspace/exec-script.sh
 }
@@ -809,7 +812,8 @@ copy_script_to_worker() {
     local remote_tmp="/tmp/vllm_script_$(date +%s)_$RANDOM.sh"
     scp -o BatchMode=yes -o StrictHostKeyChecking=no "$script_path" "$worker_ip:$remote_tmp" || { echo "Error: scp to $worker_ip failed"; exit 1; }
     ssh -o BatchMode=yes -o StrictHostKeyChecking=no "$worker_ip" \
-        "docker cp $remote_tmp $container:/workspace/exec-script.sh && \
+        "docker exec $container mkdir -p /workspace && \
+         docker cp $remote_tmp $container:/workspace/exec-script.sh && \
          docker exec $container chmod +x /workspace/exec-script.sh && \
          rm -f $remote_tmp" || { echo "Error: docker cp to worker $worker_ip failed"; exit 1; }
 }

--- a/recipes/deepseek-v4-flash-fp8-aiden.yaml
+++ b/recipes/deepseek-v4-flash-fp8-aiden.yaml
@@ -1,0 +1,94 @@
+# Recipe: DeepSeek-V4-Flash (FP8 dense + MXFP4 MoE) on 2x DGX Spark GB10, served via the
+# community aidendle94 image (native B12X MXFP4 MoE backend, up to ~1M ctx), driven by the
+# eugr launcher. Supports both Ray and no-Ray.
+#
+# Launch:
+#   no-ray:  ./run-recipe.sh deepseek-v4-flash-fp8-aiden --no-ray -d
+#   ray:     ./run-recipe.sh deepseek-v4-flash-fp8-aiden -d        (see RAY note)
+#
+# This recipe runs a THIRD-PARTY image (aidendle94/sparkrun-vllm-ds4-gb10), not this repo's
+# own vllm-node build. Two things make it work with launch-cluster.sh:
+#  1) The image ships a custom entrypoint (dsv4-vllm-entrypoint) that activates its /opt/env
+#     venv + JIT cache env and then execs vllm. Because launch-cluster.sh runs the command via
+#     `docker exec` (which bypasses the entrypoint) and clears the entrypoint on the idle
+#     container, we invoke that entrypoint binary EXPLICITLY inside the command below. Do NOT
+#     pass --keep-entrypoint: that would make the idle `sleep infinity` run as
+#     `vllm sleep infinity` and crash the container.
+#  2) The image has WORKDIR=/tmp and no /workspace dir. launch-cluster.sh now creates
+#     /workspace before copying the launch script, so this runs out of the box.
+#
+# RAY note: the aiden image may not ship Ray; no-ray (PyTorch distributed) is the tested path.
+#
+# Model snapshot note: if your HF cache `refs/main` points at a commit that only carries
+# metadata (no weight shards), HF_HUB_OFFLINE resolution fails at load time with
+# "Cannot find any model weights" (the peer node then shows a downstream gloo
+# "Connection closed by peer", which is a symptom, not the cause). If you hit that, pin the
+# snapshot that actually has weights by adding `--revision <commit>` to the serve command.
+
+recipe_version: "1"
+name: DeepSeek-V4-Flash-FP8-Aiden
+description: deepseek-ai/DeepSeek-V4-Flash (FP8 + MXFP4 MoE) on 2x DGX Spark GB10 via the aidendle94 B12X image (Ray/no-Ray, ~1M ctx)
+
+model: deepseek-ai/DeepSeek-V4-Flash
+
+cluster_only: true
+container: aidendle94/sparkrun-vllm-ds4-gb10:production-v2
+
+build_args: []
+mods: []
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 2
+  gpu_memory_utilization: 0.82
+  max_model_len: 1000000
+  max_num_seqs: 6
+  max_num_batched_tokens: 8192
+  block_size: 256
+  served_model_name: deepseek-v4-flash
+  speculative_mtp: '{"method":"mtp","num_speculative_tokens":2}'
+
+env:
+  # HF + caches pointed at the launcher's default mounts (/root/.cache/*)
+  HF_HOME: /root/.cache/huggingface
+  HF_HUB_OFFLINE: "1"
+  TRANSFORMERS_OFFLINE: "1"
+  VLLM_CACHE_ROOT: /root/.cache/vllm
+  FLASHINFER_WORKSPACE_BASE: /root/.cache/flashinfer
+  TRITON_CACHE_DIR: /root/.triton
+  # aiden native MXFP4 MoE backend (B12X)
+  VLLM_USE_B12X_MOE: "1"
+  VLLM_SPARSE_INDEXER_MAX_LOGITS_MB: "256"
+  VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
+  TORCH_CUDA_ARCH_LIST: "12.1a"
+  FLASHINFER_CUDA_ARCH_LIST: "12.1a"
+  NCCL_IGNORE_CPU_AFFINITY: "1"
+  NCCL_DEBUG: WARN
+
+# The command starts by invoking the entrypoint binary (NOT "vllm serve" directly: the venv is
+# not on PATH under docker exec). The entrypoint then execs vllm with these args.
+# run-recipe.py / make_node_script strip --distributed-executor-backend in --no-ray and inject
+# --nnodes/--node-rank/--master-* automatically.
+command: |
+  exec /usr/local/bin/dsv4-vllm-entrypoint serve deepseek-ai/DeepSeek-V4-Flash \
+    --served-model-name {served_model_name} \
+    --host {host} \
+    --port {port} \
+    --trust-remote-code \
+    --tensor-parallel-size {tensor_parallel} \
+    --pipeline-parallel-size 1 \
+    --distributed-executor-backend ray \
+    --kv-cache-dtype fp8 \
+    --block-size {block_size} \
+    --max-model-len {max_model_len} \
+    --max-num-seqs {max_num_seqs} \
+    --max-num-batched-tokens {max_num_batched_tokens} \
+    --gpu-memory-utilization {gpu_memory_utilization} \
+    --enable-prefix-caching \
+    --speculative-config '{speculative_mtp}' \
+    --tokenizer-mode deepseek_v4 \
+    --tool-call-parser deepseek_v4 \
+    --enable-auto-tool-choice \
+    --reasoning-parser deepseek_v4 \
+    --enable-flashinfer-autotune


### PR DESCRIPTION
## What

- **launch-cluster.sh**: create `/workspace` in the container before copying the launch script, so images that don't ship a `/workspace` dir (third-party / community vLLM builds) also work. `mkdir -p` is idempotent for the repo's own `vllm-node` image.
- **recipes/deepseek-v4-flash-fp8-aiden.yaml**: new recipe to serve `deepseek-ai/DeepSeek-V4-Flash` (FP8 dense + MXFP4 MoE) on 2x DGX Spark via the community `aidendle94/sparkrun-vllm-ds4-gb10` image (native B12X MXFP4 MoE backend, up to ~1M ctx). Supports Ray and no-Ray.

## Why

The aiden image is a popular community build for DeepSeek-V4-Flash on GB10 (B12X MXFP4 kernels). It ships a custom entrypoint (`dsv4-vllm-entrypoint`) and uses `WORKDIR=/tmp` (no `/workspace`). Two small things were needed to drive it from `launch-cluster.sh`:

1. The launcher copies the per-node script to `/workspace/exec-script.sh`, which failed on this image with *"Could not find the file /workspace in container"*. Fixed by creating the dir first (no-op for images that already have it).
2. Because the launcher runs the command via `docker exec` (which bypasses the image entrypoint) and clears the entrypoint on the idle `sleep infinity` container, the recipe invokes the entrypoint binary explicitly inside the command. It runs with **no** `--keep-entrypoint` (keeping it would make the idle container run `vllm sleep infinity` and crash).

## Tested

2x DGX Spark GB10, TP=2, no-Ray: container starts on both nodes, `/workspace` is created on the third-party image, weights load, `/v1/models` + a chat completion are verified, and the `B12X` MXFP4 MoE backend is selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)