### PR TITLE
feat: add recipe for Ornith-1.0-35B-FP8 deployment.

### DIFF
--- a/recipes/ornith-1.0-35b-fp8.yaml
+++ b/recipes/ornith-1.0-35b-fp8.yaml
@@ -1,0 +1,47 @@
+# Recipe: deepreinforce-ai/Ornith-1.0-35B-FP8
+# deepreinforce-ai/Ornith-1.0-35B in native FP8 format
+
+recipe_version: "1"
+name: Ornith-1.0-35B-FP8
+description: vLLM serving Ornith-1.0-35B-FP8
+
+# HuggingFace model to download (optional, for --download-model)
+model: deepreinforce-ai/Ornith-1.0-35B-FP8
+
+solo_only: true
+
+container: vllm-node
+
+# Mod required to fix slowness and crash in the cluster (tracking https://github.com/vllm-project/vllm/issues/33857)
+mods:
+  - mods/fix-qwen3-coder-next
+  - mods/fix-qwen3.5-chat-template
+
+# Default settings (can be overridden via CLI)
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 2
+  gpu_memory_utilization: 0.80
+  max_model_len: 262144
+  max_num_batched_tokens: 32768
+
+env:
+  VLLM_MARLIN_USE_ATOMIC_ADD: 1
+
+command: |
+  vllm serve deepreinforce-ai/Ornith-1.0-35B-FP8 \
+    --host {host} \
+    --port {port} \
+    --max-model-len {max_model_len} \
+    --max-num-batched-tokens {max_num_batched_tokens} \
+    --gpu-memory-utilization {gpu_memory_utilization} \
+    --enable-prefix-caching \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_xml \
+    --reasoning-parser qwen3 \
+    --trust-remote-code \
+    --kv-cache-dtype fp8 \
+    --load-format fastsafetensors \
+    --attention-backend flashinfer \
+    -tp {tensor_parallel} \

--- a/recipes/ornith-1.0-35b-fp8.yaml
+++ b/recipes/ornith-1.0-35b-fp8.yaml
@@ -12,9 +12,7 @@ solo_only: true
 
 container: vllm-node
 
-# Mod required to fix slowness and crash in the cluster (tracking https://github.com/vllm-project/vllm/issues/33857)
 mods:
-  - mods/fix-qwen3-coder-next
   - mods/fix-qwen3.5-chat-template
 
 # Default settings (can be overridden via CLI)


### PR DESCRIPTION
Based on Qwen 3.5.

Ornith-1.0 employs RL to learn to generate not only solution rollouts, but also the scallfold that drive those rollouts. By jointly optimizing the scaffold and the resulting solution, the model discovers better search trajectories and generates higher-quality solutions.

https://huggingface.co/deepreinforce-ai/Ornith-1.0-35B-FP8

| Benchmark / Evaluador | Ornith-1.0-35B | Qwen3.5-35B | Qwen3.6-35B | Gemma4-31B | Qwen3.5-397B |
| :--- | :---: | :---: | :---: | :---: | :---: |
| **Agentic Coding** | | | | | |
| Terminal-Bench 2.1 (Terminus-2) | 64.2 | 41.4 | 52.5 | 42.1 | 53.5 |
| Terminal-Bench 2.1 (Claude Code) | 62.8 | 38.9 | 49.2 | - | 48.6 |
| SWE-bench Verified | 75.6 | 70.0 | 73.4 | 52.0 | 76.4 |
| SWE-bench Pro | 50.4 | 44.6 | 49.5 | 35.7 | 51.6 |
| SWE-bench Multilingual | 69.3 | 60.3 | 67.2 | 51.7 | 69.3 |
| NL2Repo | 34.6 | 20.5 | 29.4 | 15.5 | 36.8 |
| Claw-eval Avg | 69.8 | 65.4 | 68.7 | 48.5 | 70.7 |
| SWE Atlas - QnA | 37.1 | 13.2 | 15.5 | - | 20.4 |
| SWE Atlas - RF | 29.7 | 10.2 | 11.4 | - | 18.4 |
| SWE Atlas - TW | 27.8 | 9.8 | 13.3 | - | 18.5 |