### PR TITLE
Add GLM-4.7-NVFP4 KVCacheScaleParameter arity fix + full-GLM 64K example

### DIFF
--- a/examples/vllm-glm-4.7-nvfp4-64k.sh
+++ b/examples/vllm-glm-4.7-nvfp4-64k.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# PROFILE: Salyut1/GLM-4.7-NVFP4 (full 355B GLM-4.7, NVFP4)
+# DESCRIPTION: Full GLM-4.7-NVFP4 serving at 64K context on 2x DGX Spark GB10 (TP=2)
+# NOTE: Requires --apply-mod mods/fix-Salyut1-GLM-4.7-NVFP4, and launch with --no-ray
+#       (on vLLM 0.23.x the ray executor collides with the launcher's ray cluster:
+#        "ActorHandleNotFoundError: ActorHandle objects are not valid across Ray sessions").
+#       No --enforce-eager: CUDAGraph fits alongside the 64K KV cache at
+#       --gpu-memory-utilization 0.90. Fallback for tighter units: add --enforce-eager
+#       (and/or drop to 0.88) for ~12.4 tok/s instead of ~17.5.
+# Verified: 2x GB10 (128 GB, driver 580.159.03), TP=2, 64K served, ~17.5 tok/s,
+#           tool calls working, 21K-token needle recall passed.
+
+vllm serve Salyut1/GLM-4.7-NVFP4 \
+    --attention-config.backend flashinfer \
+    --tool-call-parser glm47 \
+    --reasoning-parser glm45 \
+    --enable-auto-tool-choice \
+    -tp 2 \
+    --gpu-memory-utilization 0.90 \
+    --max-num-batched-tokens 8192 \
+    --max-num-seqs 8 \
+    --max-model-len 65536 \
+    --distributed-executor-backend ray \
+    --host 0.0.0.0 \
+    --port 8000

--- a/mods/fix-Salyut1-GLM-4.7-NVFP4/run.sh
+++ b/mods/fix-Salyut1-GLM-4.7-NVFP4/run.sh
@@ -1,3 +1,10 @@
 #!/bin/bash
 set -e
 patch -p1 -d / < glm4_moe.patch
+# Arity fix: on newer vLLM (e.g. 0.23.1rc1.dev*), glm4_moe.py routes the scalar
+# k/v scale through the stacked-param path and calls weight_loader(param, weight, shard_id)
+# -- but KVCacheScaleParameter.weight_loader is a staticmethod taking (param, weight).
+# shard_id is irrelevant for a scalar scale (per-head scales route elsewhere per its
+# docstring), so absorb and ignore the extra positional.
+sed -i 's/def weight_loader(param: torch.nn.Parameter, loaded_weight: torch.Tensor)/def weight_loader(param: torch.nn.Parameter, loaded_weight: torch.Tensor, *args)/' \
+  /usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/quantization/kv_cache.py


### PR DESCRIPTION
**Context:** this is the follow-on wall to the k/v-scale fix discussed in [Salyut1/GLM-4.7-NVFP4 · "Broken model config?" #3](https://huggingface.co/Salyut1/GLM-4.7-NVFP4/discussions/3) (my comment in that thread summarizes this fix).

On newer vLLM builds (tested on the `vllm-node-tf5` image, vLLM `0.23.1rc1.dev448`), the `fix-Salyut1-GLM-4.7-NVFP4` mod gets past the missing-scale `KeyError`, but the load then fails with:

```
TypeError: KVCacheScaleParameter.weight_loader() takes 2 positional arguments but 3 were given
→ WorkerProc failed to start → EngineCore failed to start
```

**Cause:** `glm4_moe.py` routes the scalar k/v scale through the stacked-param path and calls `weight_loader(param, loaded_weight, shard_id)`, but `KVCacheScaleParameter.weight_loader` (`vllm/model_executor/layers/quantization/kv_cache.py`) is a staticmethod taking `(param, loaded_weight)`. The loader handles a scalar scale — per-head scales route elsewhere per its docstring — so ignoring `shard_id` is safe.

**Change 1** — append a one-line `sed` to the mod's `run.sh` adding `*args` to the loader signature (re-applied on every container start).

**Change 2** — new `examples/vllm-glm-4.7-nvfp4-64k.sh`: full 355B GLM-4.7-NVFP4 at 64K context. Launch with `--no-ray` (on vLLM 0.23.x the ray executor collides with the launcher's ray cluster — `ActorHandleNotFoundError ... across Ray sessions`), no `--enforce-eager` (CUDAGraph fits the 64K KV at `--gpu-memory-utilization 0.90`).

**Validated on:** 2× DGX Spark GB10 (128 GB, driver 580.159.03), TP=2. Loads clean, serves at `max-model-len 65536`, coherent completions, tool-calls working (glm47 parser), long-context needle recall at 21K tokens passed, ~17.5 tok/s (8.89 GiB KV available vs 5.75 needed, with the batch limits + 0.90).

Happy to adjust format/placement to repo conventions.

— Cecil Ray Burnett III (Leathery Tendons)
