### PR TITLE
Add FLUX.2 — the repo's first image-generation server (NVFP4 on Black…

### DIFF
--- a/recipes/flux2-dev-torchao-nvfp4.yaml
+++ b/recipes/flux2-dev-torchao-nvfp4.yaml
@@ -1,0 +1,76 @@
+# Recipe: FLUX.2-dev + on-the-fly torchao NVFP4 (Blackwell speedup)
+# 32B rectified-flow FLUX.2-dev quantized on the fly to NVFP4 (W4A4, Triton).
+# ~4x faster than BF16 on a DGX Spark GB10 (sm_121a): 28-step 1024^2 ~33s
+# (steady, warm) vs ~2.3min BF16, and ~66GB VRAM vs ~112GB.
+#
+# NOT a vLLM model — a diffusers FastAPI server (servers/flux2/). Build first:
+#   docker build -f servers/flux2/Dockerfile -t flux2-torchao servers/flux2
+# Weights: the plain BF16 FLUX.2-dev repo (quantized on the fly at load — no
+# pre-quantized checkpoint, no modelopt).
+
+recipe_version: "1"
+name: FLUX.2-dev-torchao-NVFP4
+description: FLUX.2-dev on-the-fly torchao NVFP4 on Blackwell (OpenAI Images API)
+
+model: black-forest-labs/FLUX.2-dev
+
+container: flux2-torchao:latest
+
+solo_only: true
+
+mods: []
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+
+env:
+  # BASE BF16 FLUX.2-dev — the ONLY model needed (NVFP4 applied on the fly; no
+  # separate quantized checkpoint). HF id → downloaded to / resolved from the
+  # default HF cache (~/.cache/huggingface). Downloads on first run if absent
+  # (FLUX.2 is gated — needs an HF token in your environment).
+  MODEL_PATH: black-forest-labs/FLUX.2-dev
+  SERVED_MODEL_NAME: black-forest-labs/FLUX.2-dev
+  TORCHAO_QUANT: nvfp4         # on-the-fly quant: nvfp4 | mxfp8 | (unset=BF16)
+  # MIXED quant: keep these sensitive linears BF16, NVFP4 the rest (better
+  # quality). Default names are a FLUX.2 best-guess — verify against
+  # transformer.named_modules(). "" = full quant. Change freely; the cache is
+  # content-addressed so a new setting just makes a new cache entry.
+  TORCHAO_SKIP_MODULES: "proj_out,x_embedder,context_embedder,time_guidance_embed"
+  # Quantize once → save → fast-boot after. Content-addressed: per-config
+  # subdirs keyed by md5(model+quant+skip), so different configs coexist and
+  # switching back to a prior config still fast-loads. First boot of each key:
+  # ~2min BF16 load + quant + save; later boots: fast load of the saved copy.
+  # Nested under the auto-mounted HF cache so the saved quant persists on the
+  # host (~/.cache/huggingface/quant-cache/) and survives container rebuilds.
+  QUANT_CACHE_DIR: /root/.cache/huggingface/quant-cache/flux2-dev-nvfp4
+  DEFAULT_STEPS: "28"
+  DEFAULT_GUIDANCE: "4.0"
+  PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+  # (no HF_HUB_OFFLINE — let it download from HF / use the cache normally)
+
+# The HF cache (~/.cache/huggingface) is mounted automatically, so the model
+# download and the saved quant both persist on the host across runs.
+
+command: |
+  uvicorn server:app \
+    --host {host} \
+    --port {port}
+
+#####
+# OpenAI Images API: GET /v1/models, POST /v1/images/generations (JSON),
+# POST /v1/images/edits (multipart file upload). steps/guidance/seed are
+# extensions (extra_body / -F form fields).
+#
+# NOTES:
+#  - First request of each new SHAPE (resolution/aspect, gen vs edit) pays a
+#    one-time Triton JIT (frozen 0/N, GPU idle a few min) — NVFP4 tensors have
+#    no stable compile cache, so it recompiles per shape and doesn't persist
+#    across restart. Warm the shapes you use, or drop compile_repeated_blocks
+#    in server.py for consistent (slightly slower) behavior with no stalls.
+#  - Multi-reference edits (2+ images) are much slower (longer sequence);
+#    downscale references to reduce conditioning tokens.
+#  - SPARK-only: on-the-fly quant loads BF16 resident first (won't fit a 16GB
+#    card). CUDA 13 + Blackwell (sm_120a/121a) required for the FP4 kernels.
+#
+# Credit: PyTorch "Faster Diffusion on Blackwell (MXFP8/NVFP4 + TorchAO)".

--- a/servers/flux2/Dockerfile
+++ b/servers/flux2/Dockerfile
@@ -1,0 +1,62 @@
+# syntax=docker/dockerfile:1.6
+#
+# FLUX.2 image server with on-the-fly torchao NVFP4 quantization for Blackwell.
+# Self-contained: build with this folder as context.
+#   docker build -f servers/flux2/Dockerfile -t flux2-torchao servers/flux2
+#
+# NVFP4 (W4A4, Triton kernels) gives a real speedup on Blackwell — measured
+# ~3x on a DGX Spark GB10 (sm_121a): 28-step 1024^2 in ~45s vs ~2.3min BF16,
+# and ~40% less VRAM (~66GB vs ~112GB). Based on the PyTorch Blackwell blog:
+#   https://pytorch.org/blog/faster-diffusion-on-blackwell-mxfp8-and-nvfp4-with-diffusers-and-torchao/
+#
+# See README.md for details. Versions are pinned below (validated 2026-07-08).
+
+FROM nvidia/cuda:13.2.0-devel-ubuntu24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+# 12.1a target so native NVFP4 MMA is available on GB10 (sm_121a)
+ENV TORCH_CUDA_ARCH_LIST="12.0a;12.1a"
+ENV CUDA_HOME=/usr/local/cuda
+ENV PATH=/usr/local/cuda/bin:$PATH
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        python3 python3-dev python3-pip \
+        git curl ca-certificates libgl1 libglib2.0-0 && \
+    rm -rf /var/lib/apt/lists/*
+
+# CUDA 13 (cu130) is required for Blackwell (sm_120a/121a). torch is a cu130
+# nightly (sm_121 support); torchao (PyPI) provides the NVFP4 workflow; mslk
+# provides the NVFP4 Triton kernels (without it, torchao raises "mslk is
+# required for NVFP4 triton quantization").
+#
+# Versions below are the exact set validated on a DGX Spark GB10, 2026-07-08.
+# NOTE: torch / torchvision / mslk are cu130 *nightlies* — PyTorch prunes old
+# nightlies from the index after a few weeks. If one of these pins 404s at build
+# time, bump it to the nearest available cu130 nightly (see the index URL) and
+# expect to re-validate; the stable PyPI pins (torchao, diffusers, …) do not age.
+RUN pip install --pre \
+        torch==2.14.0.dev20260707+cu130 \
+        torchvision==0.29.0.dev20260708+cu130 \
+        --index-url https://download.pytorch.org/whl/nightly/cu130
+RUN pip install torchao==0.17.0 triton
+RUN pip install --pre mslk==2026.7.7+cu130 \
+        --index-url https://download.pytorch.org/whl/nightly/cu130
+
+# FLUX.2 pipelines (diffusers) + server stack
+RUN pip install \
+        diffusers==0.39.0 \
+        transformers==5.13.0 accelerate==1.14.0 safetensors==0.8.0 \
+        sentencepiece protobuf \
+        Pillow fastapi "uvicorn[standard]" pydantic python-multipart
+
+WORKDIR /app
+COPY server.py /app/server.py
+
+ENV PYTHONUNBUFFERED=1
+# (no forced offline — the recipe controls HF download vs cache)
+
+EXPOSE 8000
+ENTRYPOINT []
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/servers/flux2/README.md
+++ b/servers/flux2/README.md
@@ -1,0 +1,205 @@
+# FLUX.2 image server — torchao NVFP4 on Blackwell
+
+An OpenAI-compatible image server for [FLUX.2](https://huggingface.co/black-forest-labs)
+built on 🤗 diffusers, with **on-the-fly NVFP4 quantization** for a large speedup
+on NVIDIA Blackwell (sm_120a / sm_121a, e.g. DGX Spark GB10, RTX PRO 6000).
+
+The transformer is quantized to NVFP4 (W4A4, Triton kernels) at load time via
+[torchao](https://github.com/pytorch/ao) — no pre-quantized checkpoint, no
+TensorRT. Based on the PyTorch blog
+[*Faster Diffusion on Blackwell with MXFP8 and NVFP4*](https://pytorch.org/blog/faster-diffusion-on-blackwell-mxfp8-and-nvfp4-with-diffusers-and-torchao/).
+
+## Measured on a DGX Spark GB10 (sm_121a), FLUX.2-dev, 28 steps @ 1024²
+
+| | BF16 | NVFP4 (this) | speedup |
+|---|---|---|---|
+| text-to-image | ~2.3 min | **~45 s** (warm) | **~3×** |
+| single-ref edit | ~4 min 20 s | **~1 min 51 s** | **~2.3×** |
+| VRAM | ~112 GB | **~66 GB** | ~40% less |
+
+Warm steady rate ≈ **1.6 s/it**. Output quality is visually on par with BF16
+(mixed quant keeps the accuracy-sensitive layers in BF16 — see below).
+
+## Requirements
+
+- **NVIDIA Blackwell** (sm_120a / sm_121a). The NVFP4 Triton kernels need it;
+  this will not run on Ada/Hopper.
+- **CUDA 13** (the image is built on `nvidia/cuda:13.2.0`).
+- Enough VRAM/unified memory for the model — on-the-fly quant loads the BF16
+  weights resident first, so peak is BF16-sized during startup. A 128 GB GB10
+  is comfortable; a 16 GB card is not.
+- An HF token in your environment if the model is gated (FLUX.2-dev is).
+
+## Build
+
+Self-contained — build with this folder as the context:
+
+```bash
+docker build -f servers/flux2/Dockerfile -t flux2-torchao:latest servers/flux2
+```
+
+> The `torch`/`torchao`/`mslk` installs are Blackwell/CUDA-13 nightly builds;
+> the first build is slow. See the "Pinning" note in the Dockerfile.
+
+## Run
+
+Via the repo's recipe runner:
+
+```bash
+./run-recipe.sh flux2-dev-torchao-nvfp4.yaml --name flux2 --solo -d
+docker logs -f flux2      # watch: quantize (first boot) → save → serve on :8000
+```
+
+First boot of a given quant config: BF16 load + quantize + save (a few minutes).
+Later boots **fast-load the saved quant** from the HF cache mount (~seconds of
+weight load; the only remaining cost is the one-time `torch.compile` pass).
+
+## How it works
+
+Nothing exotic — it's stock diffusers + torchao, wired together so the quantize
+step happens once and the result is reused. The whole pipeline:
+
+### 1. Load & quantize (startup)
+
+```
+DiffusionPipeline.from_pretrained(MODEL_PATH, quantization_config=PipelineQuantizationConfig(...))
+```
+
+- The **BF16 checkpoint loads normally** (HF cache or local path). diffusers
+  picks the concrete pipeline class from `model_index.json`, so the same image
+  serves FLUX.2-dev, Klein, etc.
+- torchao then **quantizes the transformer's linear layers in place** to NVFP4
+  using `NVFP4DynamicActivationNVFP4WeightConfig(use_triton_kernel=True)` (or
+  MXFP8). This is a **real low-precision compute path**, not weight-only packing:
+  weights are FP4 and activations are dynamically quantized to FP4 per-tensor,
+  so the matmuls run on Blackwell's FP4 tensor cores via torchao's Triton
+  kernels. That's where the ~2–3× wall-clock speedup comes from — it is *not* a
+  memory-only trick (weight-only FP4 with BF16 math would save VRAM but not
+  time). The approach is exactly the one documented in the
+  [PyTorch Blackwell diffusion blog](https://pytorch.org/blog/faster-diffusion-on-blackwell-mxfp8-and-nvfp4-with-diffusers-and-torchao/).
+- The text encoder and VAE stay BF16 (they aren't the bottleneck), so peak
+  memory during startup is BF16-sized; the steady state is ~40% smaller.
+
+### 2. Mixed precision (quality safeguard)
+
+Fully quantizing every layer can hurt quality on the accuracy-sensitive ones
+(patch/context embedders, timestep embed, final projection). `TorchAoConfig`'s
+`modules_to_not_convert` keeps those in BF16 while NVFP4-ing the heavy
+attention/MLP stack — the bulk of the FLOPs, so you keep almost all the speed
+and lose almost none of the quality. The list is the `TORCHAO_SKIP_MODULES` env
+(substring match; empty = full quant).
+
+### 3. Save once, fast-boot after
+
+Quantizing on every boot is wasteful, so with `QUANT_CACHE_DIR` set the
+quantized transformer is written out with `save_pretrained(...)` after the first
+quantize and reloaded on subsequent boots:
+
+- The cache subdir is **content-addressed**: `md5(MODEL_PATH + quant + skip)[:12]`.
+  Different quant/skip settings get different subdirs automatically, so they
+  coexist and switching back to a prior config still fast-loads — no stale
+  cache, no manual cleanup.
+- The quant is saved as **pickled** (`safe_serialization=False`) because torchao
+  tensor subclasses don't round-trip through safetensors. Reload therefore
+  passes `use_safetensors=False` so `from_pretrained` reads the `.bin` shard
+  index instead of probing for a non-existent `.safetensors`.
+- Every step is wrapped so a cache miss/corruption **degrades gracefully** back
+  to a fresh on-the-fly quantize rather than failing to start.
+- First boot of a config: BF16 load + quantize + save (a few minutes). Later
+  boots: the weights load in seconds; the only remaining cost is the one-time
+  `torch.compile` pass (`compile_repeated_blocks`).
+
+### 4. Serving
+
+- Endpoints mirror the **OpenAI Images API**, so any OpenAI-style client works;
+  `steps`/`guidance`/`seed` are accepted as extensions.
+- A diffusers pipeline isn't thread-safe and one GPU can't run two denoise loops
+  at once, so concurrent requests are **serialized behind a lock** (they queue,
+  they don't crash).
+- Long generations **stream whitespace keepalive** while the pipeline runs, so a
+  fronting reverse-proxy / CDN idle timeout doesn't kill a multi-minute request.
+
+## Configuration (env)
+
+| var | default | meaning |
+|---|---|---|
+| `MODEL_PATH` | — | base BF16 repo: an HF id (downloaded to the HF cache) or a local path |
+| `SERVED_MODEL_NAME` | `MODEL_PATH` | id reported by `/v1/models` |
+| `TORCHAO_QUANT` | *(unset = BF16)* | `nvfp4` (W4A4, fastest) · `mxfp8` (W8A8, higher accuracy) |
+| `TORCHAO_SKIP_MODULES` | `proj_out,x_embedder,context_embedder,time_guidance_embed` | comma-separated linear-name substrings kept in BF16 (mixed quant). `""` = full quant |
+| `QUANT_CACHE_DIR` | *(unset = no cache)* | where to save/load the quantized transformer. Content-addressed by `md5(model+quant+skip)` — see below |
+| `DEFAULT_STEPS` | `4` | inference steps when the request omits `steps` (dev: use 28) |
+| `DEFAULT_GUIDANCE` | `4.0` | guidance scale when the request omits `guidance` |
+| `KEEPALIVE_SECS` | `15` | whitespace keepalive interval for long generations (proxy 5xx avoidance) |
+
+### Mixed (selective) quant
+
+Some layers are accuracy-sensitive; `TORCHAO_SKIP_MODULES` keeps them in BF16 and
+NVFP4s the rest. **Verify the names against your model** — the defaults are a
+FLUX.2 best-guess; substrings that match nothing are silently ignored (→ full
+quant). List module names with:
+
+```python
+from diffusers import Flux2Transformer2DModel
+m = Flux2Transformer2DModel.from_pretrained(MODEL_PATH, subfolder="transformer")
+print({n.split('.')[0] for n,_ in m.named_modules()})
+```
+
+### Save-once / content-addressed cache
+
+With `QUANT_CACHE_DIR` set, the quantized transformer is saved after the first
+quantize and reloaded on later boots. The subdir is keyed by
+`md5(MODEL_PATH + quant + skip)`, so different configs coexist and switching back
+to a prior config still fast-loads — no stale cache, no manual deletion. Point
+`QUANT_CACHE_DIR` at a **mounted** path (e.g. under the auto-mounted HF cache) so
+it persists across container rebuilds.
+
+## API (OpenAI Images-compatible)
+
+| method | path | body |
+|---|---|---|
+| `GET` | `/v1/models` | — |
+| `GET` | `/health` | — |
+| `POST` | `/v1/images/generations` | JSON |
+| `POST` | `/v1/images/edits` | multipart form (reference image upload) |
+
+`steps`, `guidance`, and `seed` are non-standard extensions (pass via `extra_body`
+with the OpenAI SDK, or plain JSON / `-F` form fields). Responses return
+`b64_json` (no hosted URLs).
+
+**Generate:**
+
+```bash
+curl http://localhost:8000/v1/images/generations \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt":"a red fox in snow at golden hour","size":"1024x1024","steps":28}'
+```
+
+**Edit / reference** (accepts repeated `image` fields or `image[]`):
+
+```bash
+curl http://localhost:8000/v1/images/edits \
+  -F prompt="make it a snowy night under a full moon, keep the fox" \
+  -F image=@fox.png \
+  -F size="1024x1024" -F steps=28
+```
+
+## Notes & gotchas
+
+- **First request of each new *shape* pays a one-time Triton JIT** (frozen at
+  `0/N`, GPU idle for a minute or two). NVFP4 tensors have no stable
+  `torch.compile` cache key, so it recompiles per resolution/aspect and per
+  gen-vs-edit, and does **not** persist across restart. Warm the shapes you use.
+- **Reference edits are slower** than plain generation (the reference adds
+  conditioning tokens → longer sequence). Multi-reference is slower still;
+  downscale references to cut tokens.
+- **HF downloads are silent in `docker logs`** (no TTY) — a first run sits at
+  "loading …" while tens of GB stream. Track with `du -sh` on the HF cache, not
+  the log.
+- One GPU + a non-thread-safe pipeline: concurrent requests are **serialized**
+  behind a lock (they queue, they don't race).
+
+## Credit
+
+Quantization approach from the PyTorch team's
+[Faster Diffusion on Blackwell (MXFP8 / NVFP4 + torchao)](https://pytorch.org/blog/faster-diffusion-on-blackwell-mxfp8-and-nvfp4-with-diffusers-and-torchao/).

--- a/servers/flux2/server.py
+++ b/servers/flux2/server.py
@@ -1,0 +1,295 @@
+"""OpenAI-compatible image server for FLUX.2 (diffusers).
+
+Serves any FLUX.2 checkpoint — the concrete pipeline class (Flux2Pipeline,
+Flux2KleinPipeline, …) is auto-detected from the model's model_index.json, so
+one image serves FLUX.2-dev, Klein, etc. The transformer can be quantized to
+NVFP4/MXFP8 on the fly via torchao for a large Blackwell speedup (see README).
+
+Endpoints mirror the OpenAI Images API so standard OpenAI clients work:
+  POST /v1/images/generations  (JSON)             text-to-image
+  POST /v1/images/edits        (multipart form)   image edit / multi-reference
+  GET  /v1/models  ·  GET /health
+
+OpenAI has no steps/guidance/seed fields; we accept them as optional extensions
+(clients pass via extra_body / extra form fields), defaulting per model via
+DEFAULT_STEPS/DEFAULT_GUIDANCE. response_format defaults to b64_json (no hosted
+URLs). Long generations stream whitespace keepalive so a fronting proxy's idle
+timeout doesn't fire; auth, if any, belongs at that proxy hop, not here.
+"""
+import base64
+import io
+import json
+import os
+import threading
+import time
+
+import torch
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.responses import StreamingResponse
+from PIL import Image
+from pydantic import BaseModel
+
+KEEPALIVE_SECS = int(os.environ.get("KEEPALIVE_SECS", "15"))
+
+
+def _streaming_json(work):
+    """Run work() (which returns a JSON-able dict) in a thread; emit a space
+    every KEEPALIVE_SECS while it runs so Cloudflare's ~100s idle timeout never
+    fires on long (minutes) non-streaming generation, then emit the JSON body.
+    Leading whitespace is valid JSON — clients ignore it. NOTE: status is 200 as
+    soon as streaming starts, so errors are reported in the body as {"error":..}.
+    """
+    box = {}
+
+    def run():
+        try:
+            box["result"] = work()
+        except HTTPException as e:
+            box["error"] = {"message": str(e.detail), "code": e.status_code}
+        except Exception as e:  # noqa: BLE001
+            box["error"] = {"message": f"{type(e).__name__}: {e}", "code": 500}
+
+    t = threading.Thread(target=run, daemon=True)
+    t.start()
+
+    def gen():
+        while True:
+            t.join(timeout=KEEPALIVE_SECS)
+            if not t.is_alive():
+                break
+            yield b" "
+        yield json.dumps(box.get("result") or {"error": box["error"]}).encode()
+
+    return StreamingResponse(gen(), media_type="application/json")
+
+# MODEL_PATH is normally set by the recipe (an HF id or a local path). The
+# fallback is the flagship FLUX.2-dev repo so a bare run still does something
+# sensible (it downloads to the HF cache).
+MODEL_PATH = os.environ.get("MODEL_PATH", "black-forest-labs/FLUX.2-dev")
+MODEL_ID = os.environ.get("SERVED_MODEL_NAME", MODEL_PATH)
+# Per-model defaults via env: FLUX.2-dev is not distilled (28-50 steps); the
+# distilled Klein needs only ~4. Both use guidance ~4. The recipe sets these.
+DEFAULT_STEPS = int(os.environ.get("DEFAULT_STEPS", "28"))
+DEFAULT_GUIDANCE = float(os.environ.get("DEFAULT_GUIDANCE", "4.0"))
+_CREATED = int(time.time())
+
+app = FastAPI(title="FLUX.2 (OpenAI-compatible)")
+
+print(f"loading {MODEL_PATH} (default steps={DEFAULT_STEPS}) ...", flush=True)
+# DiffusionPipeline auto-detects the concrete class (Flux2KleinPipeline /
+# Flux2Pipeline / …) from the checkpoint's model_index.json — so one server
+# image serves both klein and FLUX.2-dev.
+from diffusers import DiffusionPipeline
+# TORCHAO_QUANT selects on-the-fly torchao quantization of the transformer:
+#   nvfp4 → W4A4 fp4, fastest, Triton kernels (needs mslk)
+#   mxfp8 → W8A8 fp8, higher accuracy, a bit less speed
+#   (unset/off/bf16) → no quant, plain BF16
+# The Triton kernels JIT for the running arch (sm_120a/121a on Blackwell). The
+# BF16 weights load first and are quantized in place, so MODEL_PATH is always
+# the normal BF16 repo.
+TORCHAO_QUANT = os.environ.get("TORCHAO_QUANT", "").lower()
+if TORCHAO_QUANT in ("nvfp4", "mxfp8"):
+    from diffusers import TorchAoConfig, PipelineQuantizationConfig
+    if TORCHAO_QUANT == "nvfp4":
+        from torchao.prototype.mx_formats.inference_workflow import (
+            NVFP4DynamicActivationNVFP4WeightConfig,
+        )
+        ao_cfg = NVFP4DynamicActivationNVFP4WeightConfig(
+            use_dynamic_per_tensor_scale=True, use_triton_kernel=True)
+    else:  # mxfp8
+        from torchao.prototype.mx_formats.inference_workflow import (
+            MXDynamicActivationMXWeightConfig,
+        )
+        from torchao.prototype.mx_formats.constants import KernelPreference
+        ao_cfg = MXDynamicActivationMXWeightConfig(
+            activation_dtype=torch.float8_e4m3fn, weight_dtype=torch.float8_e4m3fn,
+            kernel_preference=KernelPreference.AUTO)
+    # MIXED / selective quant: keep accuracy-critical linears (embeddings, final
+    # projection) in BF16; NVFP4 only the heavy attention/MLP layers. Substring
+    # match; override per model via TORCHAO_SKIP_MODULES (comma-sep, "" = full).
+    # Verify names against transformer.named_modules(). Built here because it
+    # keys the cache.
+    skip = [s.strip() for s in os.environ.get(
+        "TORCHAO_SKIP_MODULES",
+        "proj_out,x_embedder,context_embedder,time_guidance_embed").split(",") if s.strip()]
+
+    # CONTENT-ADDRESSED cache: key by (model, quant, skip) so each distinct
+    # config gets its own subdir automatically — no stale cache, no manual
+    # deletion. Change quant/skip → new key → quantizes fresh & caches there;
+    # switch back → the old key's cache is still there and fast-loads. First
+    # boot of a key: ~2min BF16 load + quant + save; later boots: fast load.
+    QUANT_CACHE = os.environ.get("QUANT_CACHE_DIR")
+    cache_path = None
+    if QUANT_CACHE:
+        import hashlib
+        key = hashlib.md5(
+            f"{MODEL_PATH}|{TORCHAO_QUANT}|{','.join(skip)}".encode()).hexdigest()[:12]
+        cache_path = os.path.join(QUANT_CACHE, key)
+        print(f"  quant cache key {key} ({TORCHAO_QUANT}, skip={skip or 'none'})", flush=True)
+
+    loaded = False
+    if cache_path and os.path.isdir(cache_path) and os.listdir(cache_path):
+        try:
+            from diffusers import Flux2Transformer2DModel
+            print(f"  loading cached transformer from {cache_path}", flush=True)
+            # use_safetensors=False: the quant is saved as pickled (sharded)
+            # .bin — without this, from_pretrained probes only the safetensors
+            # names and the single-file .bin, never the .bin.index.json, and
+            # falls through to "no file found" → needless re-quantize.
+            tf = Flux2Transformer2DModel.from_pretrained(
+                cache_path, torch_dtype=torch.bfloat16, use_safetensors=False)
+            pipe = DiffusionPipeline.from_pretrained(
+                MODEL_PATH, transformer=tf, torch_dtype=torch.bfloat16).to("cuda")
+            loaded = True
+        except Exception as e:  # noqa: BLE001
+            print(f"  cache load failed ({e}); quantizing fresh", flush=True)
+    if not loaded:
+        try:
+            tao = TorchAoConfig(ao_cfg, modules_to_not_convert=skip) if skip else TorchAoConfig(ao_cfg)
+        except TypeError:  # config doesn't accept skip list on this version → full
+            print("  (modules_to_not_convert unsupported here; full quant)", flush=True)
+            tao = TorchAoConfig(ao_cfg)
+        print(f"  quantizing on-the-fly with torchao {TORCHAO_QUANT.upper()} (triton); "
+              f"BF16-kept: {skip or 'none (full)'}", flush=True)
+        pqc = PipelineQuantizationConfig(quant_mapping={"transformer": tao})
+        pipe = DiffusionPipeline.from_pretrained(
+            MODEL_PATH, torch_dtype=torch.bfloat16, quantization_config=pqc).to("cuda")
+        if cache_path:
+            try:
+                os.makedirs(cache_path, exist_ok=True)
+                pipe.transformer.save_pretrained(cache_path, safe_serialization=False)
+                print(f"  saved quantized transformer → {cache_path} (fast boot next time)", flush=True)
+            except Exception as e:  # noqa: BLE001
+                print(f"  cache save failed ({e}); staying on-the-fly", flush=True)
+    try:
+        pipe.transformer.compile_repeated_blocks(fullgraph=True)
+        print("  compiled repeated blocks", flush=True)
+    except Exception as e:  # noqa: BLE001
+        print(f"  compile_repeated_blocks skipped: {e}", flush=True)
+else:
+    pipe = DiffusionPipeline.from_pretrained(
+        MODEL_PATH, torch_dtype=torch.bfloat16).to("cuda")
+print(f"pipeline loaded: {type(pipe).__name__}", flush=True)
+
+# A diffusers pipeline is NOT thread-safe and one GPU can't run concurrent
+# denoise loops. FastAPI runs sync endpoints in a threadpool, so N simultaneous
+# requests would call pipe() at once → CUDA races / OOM / crash. Serialize:
+# concurrent callers queue and run one at a time.
+_gpu_lock = threading.Lock()
+
+
+def _parse_size(size: str):
+    try:
+        w, h = size.lower().split("x")
+        return int(w), int(h)
+    except Exception:
+        raise HTTPException(400, f"bad size '{size}', want WIDTHxHEIGHT e.g. 1024x1024")
+
+
+def _b64_png(img: Image.Image) -> str:
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+def _run(prompt, steps, guidance, w, h, seed, n, refs=None):
+    """Run the pipeline n times (seed+i each), return list of PIL images."""
+    out_imgs = []
+    for i in range(max(1, n)):
+        gen = torch.Generator(device="cuda").manual_seed(seed + i)
+        kwargs = dict(prompt=prompt, num_inference_steps=steps,
+                      guidance_scale=guidance, width=w, height=h, generator=gen)
+        if refs:
+            # Pass references UNMODIFIED (never resize — that would distort a
+            # reference you want to keep). width/height still request the output
+            # size; whether FLUX.2 honors them independently of the reference
+            # depends on the pipeline's param names — see note below.
+            kwargs["image"] = refs[0] if len(refs) == 1 else refs
+        try:
+            with _gpu_lock, torch.inference_mode():
+                out_imgs.append(pipe(**kwargs).images[0])
+        except Exception as e:
+            raise HTTPException(500, f"{type(e).__name__}: {e}")
+    return out_imgs
+
+
+def _payload(imgs, t0):
+    return {
+        "created": int(time.time()),
+        "data": [{"b64_json": _b64_png(im)} for im in imgs],
+        "_elapsed_s": round(time.time() - t0, 2),
+    }
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok", "model": MODEL_ID}
+
+
+def _model_obj():
+    return {"id": MODEL_ID, "object": "model", "created": _CREATED,
+            "owned_by": "black-forest-labs"}
+
+
+@app.get("/v1/models")
+def list_models():
+    return {"object": "list", "data": [_model_obj()]}
+
+
+@app.get("/v1/models/{model_id:path}")
+def get_model(model_id: str):
+    return _model_obj()
+
+
+class GenerationsRequest(BaseModel):
+    prompt: str
+    model: str | None = None
+    n: int = 1
+    size: str = "1024x1024"
+    response_format: str = "b64_json"
+    # non-standard extensions; default per-model via DEFAULT_STEPS/_GUIDANCE env
+    seed: int = 0
+    steps: int = DEFAULT_STEPS
+    guidance: float = DEFAULT_GUIDANCE
+
+
+@app.post("/v1/images/generations")
+def images_generations(req: GenerationsRequest):
+    t0 = time.time()
+    w, h = _parse_size(req.size)
+    # stream keepalive whitespace during the (possibly minutes-long) gen so
+    # Cloudflare's 100s idle timeout never fires on this non-streaming endpoint
+    return _streaming_json(
+        lambda: _payload(_run(req.prompt, req.steps, req.guidance,
+                              w, h, req.seed, req.n), t0))
+
+
+@app.post("/v1/images/edits")
+async def images_edits(
+    prompt: str = Form(...),
+    # Reference images arrive under TWO spellings in the wild: repeated `image` fields (curl /
+    # FastAPI convention) and `image[]` (how the official OpenAI SDKs serialize an array).
+    # Liberal server: accept both and merge, so any standard client works.
+    image: list[UploadFile] = File(default=[]),
+    image_arr: list[UploadFile] = File(default=[], alias="image[]"),
+    model: str | None = Form(None),
+    n: int = Form(1),
+    size: str = Form("1024x1024"),
+    response_format: str = Form("b64_json"),
+    seed: int = Form(0),
+    steps: int = Form(DEFAULT_STEPS),
+    guidance: float = Form(DEFAULT_GUIDANCE),
+):
+    t0 = time.time()
+    files = [*image, *image_arr]
+    if not files:
+        raise HTTPException(422, "at least one reference image is required (multipart field `image`, or `image[]`)")
+    # decode uploads + parse size up front (async/fast); the slow pipeline call
+    # runs inside the keepalive stream so Cloudflare doesn't 524 on long edits
+    try:
+        refs = [Image.open(io.BytesIO(await f.read())).convert("RGB") for f in files]
+    except Exception as e:
+        raise HTTPException(400, f"cannot decode image: {e}")
+    w, h = _parse_size(size)
+    return _streaming_json(
+        lambda: _payload(_run(prompt, steps, guidance, w, h, seed, n, refs=refs), t0))


### PR DESCRIPTION
## What

Every recipe in the repo so far serves an **LLM through vLLM** — this adds the **first image-generation model**. FLUX.2 runs as a self-contained **OpenAI Images-API server** (diffusers), so standard OpenAI clients work out of the box.

Its transformer is quantized to **NVFP4 (W4A4, Triton kernels) on the fly** with [torchao](https://github.com/pytorch/ao) for a large speedup on Blackwell (sm_120a / sm_121a) — no pre-quantized checkpoint, no TensorRT.

## Results — DGX Spark GB10 (sm_121a), FLUX.2-dev, 28 steps @ 1024²

| | BF16 | NVFP4 (this) | speedup |
|---|---|---|---|
| text-to-image | ~2.3 min | **~45 s** (warm) | **~3×** |
| single-ref edit | ~4 min 20 s | **~1 min 51 s** | **~2.3×** |
| VRAM | ~112 GB | **~66 GB** | ~40% less |

Output quality is visually on par with BF16 — mixed quant keeps accuracy-sensitive layers (`proj_out`, `x_embedder`, `context_embedder`, `time_guidance_embed`) in BF16 and NVFP4s the heavy attention/MLP stack.

## What's included

- **`servers/flux2/`** — self-contained `Dockerfile` (pinned cu130 stack) + `server.py` + a detailed `README.md`.
- **`recipes/flux2-dev-torchao-nvfp4.yaml`** — FLUX.2-dev recipe (port 8000, HF-cache download).
- **Content-addressed quant cache** — quantize once, fast-boot after; persists on the HF cache mount across rebuilds.
- **OpenAI Images API** — `/v1/images/generations`, `/v1/images/edits` (multipart reference upload), `/v1/models`.

## New `servers/` convention

Adds a top-level **`servers/<model>/`** folder for non-vLLM model servers (analogous to `mods/`). Happy to rename/relocate if you'd prefer.

## Notes for reviewers

- **Blackwell + CUDA 13 only** — the NVFP4 Triton kernels need sm_120a/121a.
- `torch`/`torchvision`/`mslk` are **cu130 nightlies**, pinned to the validated set; the Dockerfile documents how to bump when a pin ages out.
- First request of each new **shape** pays a one-time Triton JIT — documented in the README.

Based on the PyTorch team's [*Faster Diffusion on Blackwell (MXFP8 / NVFP4 + torchao)*](https://pytorch.org/blog/faster-diffusion-on-blackwell-mxfp8-and-nvfp4-with-diffusers-and-torchao/).
