### PR TITLE
Update the build scripts to use SM version for NCCL build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@
 # Limit build parallelism to reduce OOM situations
 ARG BUILD_JOBS=16
 ARG CUDA_IMAGE=nvidia/cuda:13.0.2-devel-ubuntu24.04
+ARG NCCL_NVCC_GENCODE="-gencode=arch=compute_121,code=sm_121"
 
 # =========================================================
 # STAGE 1: Base Build Image
@@ -69,6 +70,7 @@ ENV CMAKE_CUDA_COMPILER_LAUNCHER=ccache
 # 2. Set Environment Variables
 ARG TORCH_CUDA_ARCH_LIST="12.1a"
 ENV TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST}
+ARG NCCL_NVCC_GENCODE
 ENV TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas
 
 # Setup Workspace
@@ -76,11 +78,11 @@ WORKDIR $VLLM_BASE_DIR
 
 # Build NCCL with mesh support (TODO: only do it if arch is 12.1) - artifacts will be in /workspace/nccl/build/pkg/deb
 # RUN git clone -b dgxspark-3node-ring https://github.com/zyang-dev/nccl.git && \
-#     cd nccl && make -j ${BUILD_JOBS} src.build NVCC_GENCODE="-gencode=arch=compute_121,code=sm_121" && \
+#     cd nccl && make -j ${BUILD_JOBS} src.build NVCC_GENCODE="${NCCL_NVCC_GENCODE}" && \
 #     make pkg.debian.build && apt install -y --no-install-recommends --allow-downgrades ./build/pkg/deb/*.deb
 
 RUN git clone https://github.com/NVIDIA/nccl.git && \
-    cd nccl && make -j ${BUILD_JOBS} src.build NVCC_GENCODE="-gencode=arch=compute_121,code=sm_121" && \
+    cd nccl && make -j ${BUILD_JOBS} src.build NVCC_GENCODE="${NCCL_NVCC_GENCODE}" && \
     make pkg.debian.build && apt install -y --no-install-recommends --allow-downgrades --allow-change-held-packages ./build/pkg/deb/*.deb
 
 # =========================================================

--- a/build-and-copy.sh
+++ b/build-and-copy.sh
@@ -98,6 +98,15 @@ add_copy_hosts() {
     done
 }
 
+# Convert --gpu-arch value (e.g. 12.0, 12.0f, 12.1a) to NCCL NVCC_GENCODE format.
+gpu_arch_to_nccl_gencode() {
+    local arch="$1"
+    # Strip optional feature suffix (12.1a -> 12.1, 12.0f -> 12.0).
+    arch="${arch%[a-z]}"
+    local sm="${arch//./}"
+    echo "-gencode=arch=compute_${sm},code=sm_${sm}"
+}
+
 get_remote_image_id() {
     local host="$1"
     local image="$2"
@@ -383,7 +392,7 @@ usage() {
     echo "Usage: $0 [OPTIONS]"
     echo "  -t, --tag <tag>               : Local image tag (default: 'vllm-node', 'vllm-node-tf5' with --tf5, 'vllm-node-mxfp4' with --exp-mxfp4)"
     echo "  --use-wheels                  : Build runner image from prebuilt or local wheels instead of pulling ${PREBUILT_RUNNER_IMAGE}"
-    echo "  --gpu-arch <arch>             : GPU architecture for wheel/source builds (default: '${DEFAULT_GPU_ARCH_LIST}')"
+    echo "  --gpu-arch <arch>             : GPU architecture for NCCL, wheel, and source builds (default: '${DEFAULT_GPU_ARCH_LIST}')"
     echo "  --rebuild-flashinfer          : Force rebuild of FlashInfer wheels (ignore cached wheels)"
     echo "  --rebuild-vllm                : Force rebuild of vLLM wheels (ignore cached wheels)"
     echo "  --force-flashinfer-download   : Force download of FlashInfer wheels (skip cached wheel checks)"
@@ -621,6 +630,8 @@ fi
 COMMON_BUILD_FLAGS+=("--build-arg" "BUILD_JOBS=$BUILD_JOBS")
 COMMON_BUILD_FLAGS+=("--build-arg" "TORCH_CUDA_ARCH_LIST=$GPU_ARCH_LIST")
 COMMON_BUILD_FLAGS+=("--build-arg" "FLASHINFER_CUDA_ARCH_LIST=$GPU_ARCH_LIST")
+NCCL_NVCC_GENCODE="$(gpu_arch_to_nccl_gencode "$GPU_ARCH_LIST")"
+COMMON_BUILD_FLAGS+=("--build-arg" "NCCL_NVCC_GENCODE=$NCCL_NVCC_GENCODE")
 if [ -n "$NETWORK_ARG" ]; then
     COMMON_BUILD_FLAGS+=("--network" "$NETWORK_ARG")
 fi

--- a/tests/test_build_and_copy.sh
+++ b/tests/test_build_and_copy.sh
@@ -183,6 +183,7 @@ test_non_default_gpu_arch_uses_wheel_build() {
     run_build --gpu-arch 12.0f || fail "non-default gpu arch run failed"
     assert_log_not_contains '^docker pull eugr/spark-vllm:latest$'
     assert_log_contains '^docker build -t vllm-node '
+    assert_log_contains 'NCCL_NVCC_GENCODE=-gencode=arch=compute_120,code=sm_120'
     pass "non-default gpu arch uses wheel build path"
 }
 

--- a/tests/test_build_and_copy.sh
+++ b/tests/test_build_and_copy.sh
@@ -192,7 +192,8 @@ test_use_wheels_uses_wheel_build() {
     run_build --use-wheels || fail "--use-wheels run failed"
     assert_log_not_contains '^docker pull eugr/spark-vllm:latest$'
     assert_log_contains '^docker build -t vllm-node '
-    pass "--use-wheels preserves wheel build path"
+    assert_log_contains 'NCCL_NVCC_GENCODE=-gencode=arch=compute_121,code=sm_121'
+    pass "--use-wheels preserves wheel build path with default NCCL gencode"
 }
 
 test_cleanup_stays_prebuilt() {


### PR DESCRIPTION
Currently, the NCCL version is hardcoded to SM 12.1, but with this change, the --gpu-arch value is used to determine the correct NCCL version when build it from source. This is needed if we want to generate builds for different devices.