### PR TITLE
Add DeepSeek-V4-Flash-DSpark recipe + SM120 topk fix

### DIFF
--- a/mods/fix-dspark-sm120-topk/run.sh
+++ b/mods/fix-dspark-sm120-topk/run.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# fix-dspark-sm120-topk — let DSpark serve on SM120 (DGX Spark / GB10, sm_121 → sm120).
+#
+# Problem: DeepSeek-V4-Flash-DSpark's draft runs a sparse-MLA decode with topk=256, but
+# FlashInfer's SM120 `decode_dsv4` kernel only has compiled buckets {128, 512, 1024}
+# (see _DECODE_DSV4_DISPATCH in flashinfer/mla/_sparse_mla_sm120.py). topk=256 sits in
+# the gap → the dispatcher falls through to the paged kernel, which asserts
+# `num_tokens > 64` and crashes during sparse-MLA warmup:
+#   tvm.error.InternalError: Check failed: num_tokens > 64 (5 vs. 64) :
+#   Decode (num_tokens <= 64) must go through ... sparse_mla_sm120_decode_dsv4
+# (The main model uses topk=128 and is unaffected; only the DSpark draft asks for 256.)
+#
+# Fix: round an unsupported draft topk DOWN to the nearest supported bucket (256 -> 128)
+# right before dispatch — slice the indices to that width and clamp topk_length.
+#
+# Why this is correctness-safe: the DSpark draft is a SPECULATOR. Every token it proposes
+# is verified by the full target model before emission, so reshaping the draft's own
+# attention can only change accept-length (speed), never the emitted output. Rounding down
+# drops the lowest-ranked sparse candidates from the draft's attention only.
+#
+# If draft accept-length suffers, replace the "round down" with "pad up" (256 -> 512 with
+# -1 sentinels + real topk_length) to keep all candidates — lossless but needs matching
+# scratch (num_splits) sizing.
+set -e
+F="$(python3 -c 'import os,flashinfer; print(os.path.join(os.path.dirname(flashinfer.__file__),"mla","_sparse_mla_sm120.py"))' 2>/dev/null)"
+[ -f "$F" ] || { echo "[fix-dspark-sm120-topk] ERROR: flashinfer _sparse_mla_sm120.py not found ($F)" >&2; exit 1; }
+
+python3 - "$F" <<'PY'
+import sys
+f = sys.argv[1]
+s = open(f).read()
+if "fix-dspark-sm120-topk" in s:
+    print("[fix-dspark-sm120-topk] already applied"); raise SystemExit(0)
+anchor = "        extra_topk = int(extra_indices.size(-1)) if extra_indices is not None else 0\n"
+if anchor not in s:
+    raise SystemExit("[fix-dspark-sm120-topk] ERROR: anchor not found — flashinfer version drift")
+inject = (
+    "        # fix-dspark-sm120-topk: route an unsupported topk (e.g. the DSpark draft's\n"
+    "        # 256) to the nearest supported decode_dsv4 bucket. Speculator draft only —\n"
+    "        # the target verifies all proposals, so this affects accept-length, not output.\n"
+    "        _DSV4_TOPK_OK = (128, 512, 1024)\n"
+    "        if model_type == _MODEL_TYPE_DSV4 and topk not in _DSV4_TOPK_OK:\n"
+    "            _lo = [b for b in _DSV4_TOPK_OK if b <= topk]\n"
+    "            _tgt = max(_lo) if _lo else min(_DSV4_TOPK_OK)\n"
+    "            indices = indices[..., :_tgt].contiguous()\n"
+    "            if topk_length is not None:\n"
+    "                topk_length = topk_length.clamp(max=_tgt)\n"
+    "            topk = _tgt\n"
+)
+open(f, "w").write(s.replace(anchor, anchor + inject, 1))
+print("[fix-dspark-sm120-topk] applied: topk rounding installed before decode_dsv4 dispatch")
+PY
+python3 -c "import ast; ast.parse(open('$F').read()); print('[fix-dspark-sm120-topk] verified (AST valid)')"

--- a/recipes/deepseek-v4-flash-dspark.yaml
+++ b/recipes/deepseek-v4-flash-dspark.yaml
@@ -1,0 +1,84 @@
+# Recipe: DeepSeek V4 Flash — DSpark speculative decoding
+# Same as deepseek-v4-flash.yaml but with DSpark speculation instead of MTP.
+#
+# DSpark is a Markov multi-token speculation module baked into the
+# DeepSeek-V4-Flash-DSpark checkpoint (dspark_block_size 5, target layers
+# [40,41,42], markov_rank 256).
+#
+# REQUIRES a vllm-node recent enough to include the DSpark method (vLLM #46995).
+# An older/cached image errors "unknown speculative method 'dspark'" at startup —
+# rebuild from main (`build-and-copy.sh --rebuild-vllm`) or use a recent nightly.
+# The DeepSeek-V4 cute-DSL/preset fixes required to load on main (VLLM_PRESET_PRS
+# 47392 47618) are applied automatically by the main build, same as
+# deepseek-v4-flash.yaml — no manual step.
+#
+# SM120 note (DGX Spark / GB10): the DSpark draft issues a sparse-MLA decode with
+# topk=256, which FlashInfer's SM120 decode_dsv4 kernel has no compiled bucket for
+# ({128,512,1024}), so warmup crashes with `num_tokens > 64`. The bundled mod
+# `mods/fix-dspark-sm120-topk` rounds the draft's topk to a supported bucket
+# (correctness-safe — the target verifies every drafted token). Remove the mod on
+# platforms/kernels that already support topk=256.
+
+recipe_version: "1"
+name: DeepSeek-V4-Flash-DSpark
+description: vLLM serving deepseek-ai/DeepSeek-V4-Flash-DSpark (DSpark speculation) on a DGX Spark cluster
+
+# HuggingFace model to download (optional, for --download-model)
+model: deepseek-ai/DeepSeek-V4-Flash-DSpark
+
+# Container image to use
+container: vllm-node
+
+# Can only be run in a cluster
+cluster_only: true
+
+# DSpark draft topk fix for SM120 (see header)
+mods:
+  - mods/fix-dspark-sm120-topk
+
+# Default settings (can be overridden via CLI where supported)
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 2
+  # DSpark's persistent draft adds memory pressure the MTP recipe doesn't have.
+  # 0.85 / 200k loads the draft cleanly and sizes a healthy KV pool on 2x GB10;
+  # climb max_model_len from here and re-read the "GPU KV cache size" line.
+  gpu_memory_utilization: 0.85
+  max_model_len: 200000
+  block_size: 256
+  max_num_seqs: 4
+  max_num_batched_tokens: 8192
+  # DSpark requires num_speculative_tokens >= dspark_block_size (5).
+  num_speculative_tokens: 5
+
+# Environment variables
+env:
+  DG_JIT_USE_NVRTC: "0"
+  VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
+  VLLM_USE_BREAKABLE_CUDAGRAPH: "0"
+
+# The vLLM serve command template
+command: |
+  vllm serve deepseek-ai/DeepSeek-V4-Flash-DSpark \
+      --host {host} \
+      --port {port} \
+      --trust-remote-code \
+      --tensor-parallel-size {tensor_parallel} \
+      --kv-cache-dtype fp8_ds_mla \
+      --block-size {block_size} \
+      --max-model-len {max_model_len} \
+      --max-num-seqs {max_num_seqs} \
+      --max-num-batched-tokens {max_num_batched_tokens} \
+      --gpu-memory-utilization {gpu_memory_utilization} \
+      --enable-prefix-caching \
+      --speculative-config '{{"method":"dspark","num_speculative_tokens":{num_speculative_tokens},"draft_sample_method":"probabilistic"}}' \
+      --tokenizer-mode deepseek_v4 \
+      --distributed-executor-backend ray \
+      --tool-call-parser deepseek_v4 \
+      --enable-auto-tool-choice \
+      --reasoning-parser deepseek_v4 \
+      --reasoning-config '{{"reasoning_parser":"deepseek_v4","reasoning_start_str":"","reasoning_end_str":""}}' \
+      --default-chat-template-kwargs.thinking=true \
+      --default-chat-template-kwargs.reasoning_effort=high \
+      --load-format instanttensor


### PR DESCRIPTION
DSpark speculative decoding for DeepSeek-V4-Flash on a DGX Spark cluster. Minimal delta off deepseek-v4-flash.yaml: -DSpark checkpoint + method:dspark.

Includes mods/fix-dspark-sm120-topk: the DSpark draft issues a sparse-MLA decode with topk=256, which FlashInfer's SM120 decode_dsv4 kernel has no compiled bucket for ({128,512,1024}) -> it falls through to the paged kernel and crashes at warmup with 'num_tokens > 64'. The mod rounds the draft's topk to the nearest supported bucket (256->128). Correctness-safe: the draft is a speculator, so the target verifies every proposed token; this only affects accept-length, never output. Verified: clean output, mean accept-length ~4 and ~53 tok/s on code workloads (workload-dependent, per the upstream DSpark notes).