### PR TITLE
Add Gemma-4-31B-IT-NVFP4 recipe; MTP + per-request stats for gemma4-26b/31b

### DIFF
--- a/recipes/gemma4-26b-a4b-nvfp4.yaml
+++ b/recipes/gemma4-26b-a4b-nvfp4.yaml
@@ -46,6 +46,8 @@ command: |
     --reasoning-parser gemma4 \
     --kv-cache-dtype fp8 \
     --max-num-batched-tokens {max_num_batched_tokens} \
+    --enable-per-request-metrics \
+    --enable-force-include-usage \
     --speculative-config '{{"method":"mtp","model":"google/gemma-4-26B-A4B-it-assistant","num_speculative_tokens":4, "moe_backend": "triton"}}' \
     -tp {tensor_parallel} --distributed-executor-backend ray
     

--- a/recipes/gemma4-31b-it-nvfp4.yaml
+++ b/recipes/gemma4-31b-it-nvfp4.yaml
@@ -17,8 +17,16 @@
 # PR (vllm-project/vllm#41745, merged 2026-05-06) — confirmed present in
 # the eugr/spark-vllm:latest nightly pulled 2026-07-19.
 #
-# Load-tested on this box (2026-07-19), without MTP: pp ~2060 tok/s,
-# tg ~6.8 tok/s on a single GB10 GPU. MTP itself not yet benchmarked here.
+# Load-tested on this box (2026-07-19): pp ~2060 tok/s / tg ~6.8 tok/s
+# without MTP; pp ~1900 tok/s / tg ~16 tok/s with MTP (~2.3x tg speedup).
+#
+# --enable-force-include-usage: without this, vLLM only emits the final
+# usage/metrics SSE chunk if the client explicitly sets
+# stream_options.include_usage=true. Most real streaming clients don't, so
+# llama-swap logged "no valid JSON data found in stream, recording minimal
+# metrics" and showed 0 t/s in its Activity view even with
+# --enable-per-request-metrics on. This forces that chunk on every request
+# regardless of client.
 
 recipe_version: "1"
 name: Gemma4-31B-IT-NVFP4
@@ -55,4 +63,6 @@ command: |
     --tool-call-parser gemma4 \
     --reasoning-parser gemma4 \
     --kv-cache-dtype fp8 \
+    --enable-per-request-metrics \
+    --enable-force-include-usage \
     --speculative-config '{{"method":"mtp","model":"google/gemma-4-31B-it-assistant","num_speculative_tokens":4}}'

--- a/recipes/gemma4-31b-it-nvfp4.yaml
+++ b/recipes/gemma4-31b-it-nvfp4.yaml
@@ -1,0 +1,58 @@
+# Recipe: Gemma4-31B-IT-NVFP4
+# Gemma-4-31B-IT (dense, not MoE) in NVIDIA NVFP4 quantization.
+#
+# Locally authored (not from upstream eugr/spark-vllm-docker). NVIDIA's own
+# model card example targets an 8x H100 node (--tensor-parallel-size 8);
+# adapted here for a single GB10 GPU the same way qwen3.6-27b-nvfp4.yaml
+# adapts its MoE sibling recipe for dense models: tensor_parallel: 1, no
+# --moe-backend (dense model, no expert layers). Tool/reasoning parser
+# flags carry over from gemma4-26b-a4b-nvfp4.yaml since they're
+# Gemma4-architecture-family flags, not specific to that checkpoint's MoE
+# variant.
+#
+# MTP speculative decoding: Google ships a dedicated ~0.5B drafter,
+# google/gemma-4-31B-it-assistant, for this checkpoint (same pattern as the
+# 26B-A4B recipe's assistant model, just no "moe_backend" key since there's
+# no MoE draft/verify path here). Requires vLLM built after the Gemma4 MTP
+# PR (vllm-project/vllm#41745, merged 2026-05-06) — confirmed present in
+# the eugr/spark-vllm:latest nightly pulled 2026-07-19.
+#
+# Load-tested on this box (2026-07-19), without MTP: pp ~2060 tok/s,
+# tg ~6.8 tok/s on a single GB10 GPU. MTP itself not yet benchmarked here.
+
+recipe_version: "1"
+name: Gemma4-31B-IT-NVFP4
+description: vLLM serving nvidia/Gemma-4-31B-IT-NVFP4 (dense)
+
+model: nvidia/Gemma-4-31B-IT-NVFP4
+
+cluster_only: false
+solo_only: true
+
+container: vllm-node
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 1
+  gpu_memory_utilization: 0.7
+  max_model_len: 262144
+  max_num_batched_tokens: 8192
+
+env: {}
+
+command: |
+  vllm serve nvidia/Gemma-4-31B-IT-NVFP4 \
+    --host {host} \
+    --port {port} \
+    --tensor-parallel-size {tensor_parallel} \
+    --max-model-len {max_model_len} \
+    --gpu-memory-utilization {gpu_memory_utilization} \
+    --max-num-batched-tokens {max_num_batched_tokens} \
+    --load-format instanttensor \
+    --enable-prefix-caching \
+    --enable-auto-tool-choice \
+    --tool-call-parser gemma4 \
+    --reasoning-parser gemma4 \
+    --kv-cache-dtype fp8 \
+    --speculative-config '{{"method":"mtp","model":"google/gemma-4-31B-it-assistant","num_speculative_tokens":4}}'


### PR DESCRIPTION
## Summary
- Adds a new recipe for `nvidia/Gemma-4-31B-IT-NVFP4` (dense, not MoE like the existing 26B-A4B recipe). Adapted from NVIDIA's own model-card example, which targets an 8x H100 tensor-parallel setup, down to `tensor_parallel: 1` for single-GPU boxes.
- Adds MTP speculative decoding to the new 31B recipe via Google's dedicated `google/gemma-4-31B-it-assistant` drafter (same pattern the existing 26B-A4B recipe already uses with its own assistant checkpoint).
- Adds `--enable-per-request-metrics` and `--enable-force-include-usage` to both gemma4 recipes.

## Why the two extra flags
Without `--enable-force-include-usage`, vLLM only emits the final usage/metrics SSE chunk on a streaming response if the *client* explicitly sets `stream_options.include_usage=true`. Most real streaming clients don't set this, so anything relying on per-request stats from a streaming response (e.g. a reverse proxy/dashboard) silently sees zero prompt/generation speed even with `--enable-per-request-metrics` on. Forcing it server-side fixes that for every client without requiring client-side changes.

## Test plan
Load-tested both recipes end-to-end on a single NVIDIA GB10 (DGX Spark):
- [x] `gemma4-26b-a4b-nvfp4` loads and serves correctly with the new flags; pp ~6590 tok/s, tg ~49 tok/s
- [x] `gemma4-31b-it-nvfp4` loads and serves correctly with MTP; pp ~1900 tok/s, tg ~16 tok/s (vs ~6.8 tok/s without MTP, ~2.3x speedup)
- [x] Verified via raw SSE capture that the final chunk of a real streaming request now includes both `usage` and `metrics` (`tokens_per_second`, `time_to_first_token_ms`, etc.) with no special client-side request options