### PR TITLE
Fix JSON-valued CLI args that sparkrun's renderer cannot substitute

### DIFF
--- a/recipes/4x-spark-cluster/nemotron-3-ultra-nvfp4.yaml
+++ b/recipes/4x-spark-cluster/nemotron-3-ultra-nvfp4.yaml
@@ -28,6 +28,8 @@ defaults:
   max_model_len: 262144
   max_num_seqs: 2
   max_num_batched_tokens: 16384
+  # JSON-valued args live here whole: the renderer can't substitute inside JSON braces
+  speculative_config: '{"method":"mtp","num_speculative_tokens":4,"moe_backend":"triton","attention_backend":"TRITON_ATTN"}'
 
 command: |
   vllm serve nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4 \
@@ -54,7 +56,7 @@ command: |
     -cc.mode 0 \
     -cc.cudagraph_mode FULL_DECODE_ONLY \
     --cudagraph-capture-sizes 5 10 15 20 \
-    --speculative-config '{{"method":"mtp","num_speculative_tokens":4,"moe_backend":"triton","attention_backend":"TRITON_ATTN"}}' \
+    --speculative-config '{speculative_config}' \
     --enable-prefix-caching \
     --enable-flashinfer-autotune \
     --reasoning-parser nemotron_v3 \

--- a/recipes/deepseek-v4-flash.yaml
+++ b/recipes/deepseek-v4-flash.yaml
@@ -27,7 +27,9 @@ defaults:
   block_size: 256
   max_num_seqs: 4
   max_num_batched_tokens: 8192
-  num_speculative_tokens: 2
+  # JSON-valued args live here whole: the renderer can't substitute inside JSON braces
+  speculative_config: '{"method":"mtp","num_speculative_tokens":2}'
+  reasoning_config: '{"reasoning_parser":"deepseek_v4","reasoning_start_str":"","reasoning_end_str":""}'
 
 # Environment variables
 env:
@@ -49,13 +51,13 @@ command: |
       --max-num-batched-tokens {max_num_batched_tokens} \
       --gpu-memory-utilization {gpu_memory_utilization} \
       --enable-prefix-caching \
-      --speculative-config '{{"method":"mtp","num_speculative_tokens":{num_speculative_tokens}}}' \
+      --speculative-config '{speculative_config}' \
       --tokenizer-mode deepseek_v4 \
       --distributed-executor-backend ray \
       --tool-call-parser deepseek_v4 \
       --enable-auto-tool-choice \
       --reasoning-parser deepseek_v4 \
-      --reasoning-config '{{"reasoning_parser":"deepseek_v4","reasoning_start_str":"","reasoning_end_str":""}}' \
+      --reasoning-config '{reasoning_config}' \
       --default-chat-template-kwargs.thinking=true \
       --default-chat-template-kwargs.reasoning_effort=high \
       --load-format instanttensor

--- a/recipes/diffusion-gemma-bf16-thinking.yaml
+++ b/recipes/diffusion-gemma-bf16-thinking.yaml
@@ -25,6 +25,10 @@ defaults:
   gpu_memory_utilization: 0.8
   max_model_len: 262144
   max_num_seqs: 10
+  # JSON-valued args live here whole: the renderer can't substitute inside JSON braces
+  diffusion_config: '{"canvas_length":256}'
+  override_generation_config: '{"max_new_tokens": null}'
+  default_chat_template_kwargs: '{"enable_thinking": true}'
 
 # Environment variables
 env: {}
@@ -43,8 +47,8 @@ command: |
     --attention-backend TRITON_ATTN \
     --max-num-seqs {max_num_seqs} \
     --enable-prefix-caching \
-    --diffusion-config '{{"canvas_length":256}}' \
-    --override-generation-config '{{"max_new_tokens": null}}' \
+    --diffusion-config '{diffusion_config}' \
+    --override-generation-config '{override_generation_config}' \
     --reasoning-parser gemma4 \
-    --default-chat-template-kwargs '{{"enable_thinking": true}}' \
+    --default-chat-template-kwargs '{default_chat_template_kwargs}' \
     --moe-backend triton

--- a/recipes/diffusion-gemma-bf16.yaml
+++ b/recipes/diffusion-gemma-bf16.yaml
@@ -25,6 +25,10 @@ defaults:
   gpu_memory_utilization: 0.8
   max_model_len: 262144
   max_num_seqs: 10
+  # JSON-valued args live here whole: the renderer can't substitute inside JSON braces
+  diffusion_config: '{"canvas_length":256}'
+  override_generation_config: '{"max_new_tokens": null}'
+  default_chat_template_kwargs: '{"enable_thinking": false}'
 
 # Environment variables
 env: {}
@@ -43,9 +47,9 @@ command: |
     --attention-backend TRITON_ATTN \
     --max-num-seqs {max_num_seqs} \
     --enable-prefix-caching \
-    --diffusion-config '{{"canvas_length":256}}' \
-    --override-generation-config '{{"max_new_tokens": null}}' \
+    --diffusion-config '{diffusion_config}' \
+    --override-generation-config '{override_generation_config}' \
     --reasoning-parser gemma4 \
-    --default-chat-template-kwargs '{{"enable_thinking": false}}' \
+    --default-chat-template-kwargs '{default_chat_template_kwargs}' \
     --chat-template fixed_chat_template.jinja \
     --moe-backend triton 

--- a/recipes/diffusion-gemma-nvfp4-thinking.yaml
+++ b/recipes/diffusion-gemma-nvfp4-thinking.yaml
@@ -24,6 +24,10 @@ defaults:
   host: 0.0.0.0
   gpu_memory_utilization: 0.8
   max_model_len: 262144
+  # JSON-valued args live here whole: the renderer can't substitute inside JSON braces
+  diffusion_config: '{"canvas_length":256}'
+  override_generation_config: '{"max_new_tokens": null}'
+  default_chat_template_kwargs: '{"enable_thinking": true}'
 
 # Environment variables
 env: {}
@@ -41,7 +45,7 @@ command: |
     --load-format fastsafetensors \
     --attention-backend TRITON_ATTN \
     --enable-prefix-caching \
-    --diffusion-config '{{"canvas_length":256}}' \
-    --override-generation-config '{{"max_new_tokens": null}}' \
+    --diffusion-config '{diffusion_config}' \
+    --override-generation-config '{override_generation_config}' \
     --reasoning-parser gemma4 \
-    --default-chat-template-kwargs '{{"enable_thinking": true}}'
+    --default-chat-template-kwargs '{default_chat_template_kwargs}'

--- a/recipes/diffusion-gemma-nvfp4.yaml
+++ b/recipes/diffusion-gemma-nvfp4.yaml
@@ -24,6 +24,10 @@ defaults:
   host: 0.0.0.0
   gpu_memory_utilization: 0.8
   max_model_len: 262144
+  # JSON-valued args live here whole: the renderer can't substitute inside JSON braces
+  diffusion_config: '{"canvas_length":256}'
+  override_generation_config: '{"max_new_tokens": null}'
+  default_chat_template_kwargs: '{"enable_thinking": false}'
 
 # Environment variables
 env: {}
@@ -41,8 +45,8 @@ command: |
     --load-format fastsafetensors \
     --attention-backend TRITON_ATTN \
     --enable-prefix-caching \
-    --diffusion-config '{{"canvas_length":256}}' \
-    --override-generation-config '{{"max_new_tokens": null}}' \
+    --diffusion-config '{diffusion_config}' \
+    --override-generation-config '{override_generation_config}' \
     --chat-template fixed_chat_template.jinja \
     --reasoning-parser gemma4 \
-    --default-chat-template-kwargs '{{"enable_thinking": false}}'
+    --default-chat-template-kwargs '{default_chat_template_kwargs}'

--- a/recipes/gemma4-26b-a4b-nvfp4.yaml
+++ b/recipes/gemma4-26b-a4b-nvfp4.yaml
@@ -28,6 +28,8 @@ defaults:
   gpu_memory_utilization: 0.7
   max_model_len: 262144
   max_num_batched_tokens: 8192
+  # JSON-valued args live here whole: the renderer can't substitute inside JSON braces
+  speculative_config: '{"method":"mtp","model":"google/gemma-4-26B-A4B-it-assistant","num_speculative_tokens":4, "moe_backend": "triton"}'
 
 # Environment variables
 env: {}
@@ -46,6 +48,6 @@ command: |
     --reasoning-parser gemma4 \
     --kv-cache-dtype fp8 \
     --max-num-batched-tokens {max_num_batched_tokens} \
-    --speculative-config '{{"method":"mtp","model":"google/gemma-4-26B-A4B-it-assistant","num_speculative_tokens":4, "moe_backend": "triton"}}' \
+    --speculative-config '{speculative_config}' \
     -tp {tensor_parallel} --distributed-executor-backend ray
     

--- a/recipes/qwen3.6-35b-a3b-fp8-dflash.yaml
+++ b/recipes/qwen3.6-35b-a3b-fp8-dflash.yaml
@@ -26,6 +26,8 @@ defaults:
   gpu_memory_utilization: 0.8
   max_model_len: 262144
   max_num_batched_tokens: 16384
+  # JSON-valued args live here whole: the renderer can't substitute inside JSON braces
+  speculative_config: '{"method": "dflash", "model": "z-lab/Qwen3.6-35B-A3B-DFlash", "num_speculative_tokens": 15}'
 
 # Environment variables
 env: 
@@ -45,6 +47,6 @@ command: |
     --load-format fastsafetensors \
     --attention-backend flash_attn \
     --chat-template fixed_chat_template.jinja \
-    --speculative-config '{{"method": "dflash", "model": "z-lab/Qwen3.6-35B-A3B-DFlash", "num_speculative_tokens": 15}}' \
+    --speculative-config '{speculative_config}' \
     -tp {tensor_parallel} \
     --distributed-executor-backend ray

--- a/recipes/qwen3.6-35b-a3b-nvfp4.yaml
+++ b/recipes/qwen3.6-35b-a3b-nvfp4.yaml
@@ -20,6 +20,8 @@ defaults:
   max_model_len: 262144
   max_num_seqs: 4
   max_num_batched_tokens: 8192
+  # JSON-valued args live here whole: the renderer can't substitute inside JSON braces
+  speculative_config: '{"method":"mtp","num_speculative_tokens":3,"moe_backend":"triton"}'
 
 # Environment variables
 env:
@@ -42,7 +44,7 @@ command: |
     --enable-chunked-prefill \
     --async-scheduling \
     --enable-prefix-caching \
-    --speculative-config '{{"method":"mtp","num_speculative_tokens":3,"moe_backend":"triton"}}' \
+    --speculative-config '{speculative_config}' \
     --load-format fastsafetensors \
     --reasoning-parser qwen3 \
     --tool-call-parser qwen3_xml \


### PR DESCRIPTION
## Bug

Running `deepseek-v4-flash` (and 8 other recipes) with current sparkrun (0.2.40) fails at vllm argument parsing:

```
usage: vllm serve [model_tag] [options]
vllm serve: error: argument --speculative-config/-sc: Value {{"method":"mtp","num_speculative_tokens":{num_speculative_tokens}}} cannot be converted to <function loads at 0xecd492b294e0>.
```

The template text reaches vllm completely un-substituted.

## Root cause

The recipes use `str.format()`-style conventions (`{{` brace escaping, placeholders nested inside JSON), but sparkrun renders `command:` templates with a regex substituter (`vpd.legacy.arguments.arg_substitute`, non-greedy `\{(.*?)\}`), called in a loop from `Recipe.render_command`. Two consequences:

1. `{{` is not an escape — it is just a literal character the regex trips over.
2. For a token like `'{{"method":"mtp","num_speculative_tokens":{num_speculative_tokens}}}'`, the first regex match spans from the leading brace to the *first* `}` — the extracted "variable name" is the whole JSON blob, which matches nothing, so the original text is put back verbatim. The inner placeholder is unreachable no matter how many passes run.

Even JSON args with no inner placeholder (e.g. `--diffusion-config '{{"canvas_length":256}}'`) are broken: the doubled braces are never collapsed, so vllm receives `{{...}}`, which is invalid JSON.

## Fix

Move each JSON blob into a `defaults:` variable and reference it whole:

```yaml
defaults:
  speculative_config: '{"method":"mtp","num_speculative_tokens":2}'
command: |
  ... --speculative-config '{speculative_config}' \
```

`render_command`'s nested-substitution loop resolves the variable on the first pass; on the second pass the substituted single-brace JSON matches no known variable and passes through untouched. As a bonus the JSON stays overridable via user config, like any other default.

`deepseek-v4-flash`'s `num_speculative_tokens` default is folded into `speculative_config` (it could never be substituted independently anyway).

## Scope

18 args across 9 recipes: `deepseek-v4-flash`, `qwen3.6-35b-a3b-nvfp4`, `qwen3.6-35b-a3b-fp8-dflash`, `gemma4-26b-a4b-nvfp4`, `4x-spark-cluster/nemotron-3-ultra-nvfp4`, and the four `diffusion-gemma-*` variants.

## Verification

- All 31 recipes in the repo rendered through sparkrun 0.2.40's `Recipe.render_command`; every `--*-config` / `--default-chat-template-kwargs` value now parses with `json.loads`, and no `{placeholder}` tokens remain.
- End-to-end on a 2-node DGX Spark cluster: the fixed `deepseek-v4-flash` recipe launches, vllm passes argparse with `--speculative-config {"method":"mtp","num_speculative_tokens":2}`, serves `/health`, and completes chat requests.