### PR TITLE
feat: serve multiple models at once with per-recipe cluster placement

### DIFF
--- a/.github/workflows/test-recipes.yml
+++ b/.github/workflows/test-recipes.yml
@@ -6,16 +6,22 @@ on:
     paths:
       - 'run-recipe.py'
       - 'run-recipe.sh'
+      - 'run-stack.py'
+      - 'run-stack.sh'
       - 'launch-cluster.sh'
       - 'recipes/**'
+      - 'stacks/**'
       - 'tests/**'
       - '.github/workflows/test-recipes.yml'
   pull_request:
     paths:
       - 'run-recipe.py'
       - 'run-recipe.sh'
+      - 'run-stack.py'
+      - 'run-stack.sh'
       - 'launch-cluster.sh'
       - 'recipes/**'
+      - 'stacks/**'
       - 'tests/**'
       - '.github/workflows/test-recipes.yml'
   workflow_dispatch:
@@ -43,14 +49,18 @@ jobs:
     
     - name: Make scripts executable
       run: |
-        chmod +x run-recipe.py run-recipe.sh launch-cluster.sh
-        chmod +x tests/test_recipes.sh tests/test_launch_cluster_image_sync.sh
-    
+        chmod +x run-recipe.py run-recipe.sh run-stack.py run-stack.sh launch-cluster.sh
+        chmod +x tests/test_recipes.sh tests/test_stack.sh tests/test_launch_cluster_image_sync.sh
+
     - name: Run recipe integration tests
       run: |
         ./tests/test_recipes.sh -v
         ./tests/test_launch_cluster_image_sync.sh
-    
+
+    - name: Run stack integration tests
+      run: |
+        ./tests/test_stack.sh -v
+
     - name: Verify all recipes with dry-run
       run: |
         for recipe in recipes/*.yaml; do
@@ -60,5 +70,40 @@ jobs:
             ./run-recipe.py "$name" --dry-run -n "10.0.0.1,10.0.0.2" || exit 1
           else
             ./run-recipe.py "$name" --dry-run --solo || exit 1
+          fi
+        done
+
+    - name: Verify all stacks with dry-run
+      run: |
+        # Every stack must dry-run clean. Default: verify against a synthetic
+        # 2-node cluster (so 'placement: all' resolves distributed and pinned
+        # 'placement: <IP>' resolves to its node). run-stack.py exits 3 when
+        # the ONLY problem is a recipe's own solo_only/cluster_only flag
+        # forbidding the resolved mode -- such a stack is legitimately
+        # single-host, so re-verify it with no cluster configured. Any OTHER
+        # failure (bad recipe, duplicate master_port, unknown placement IP,
+        # per-node port clash) is a real error and fails CI even though a
+        # no-cluster run might have passed.
+        # The synthetic node IPs must cover every 'placement: <IP>' pinned by a
+        # stack in stacks/, or that stack fails load-time placement validation.
+        # Keep these in sync with the IPs used by the shipped example stacks.
+        printf 'CLUSTER_NODES="10.0.1.1,10.0.1.2"\nLOCAL_IP="10.0.1.1"\n' > /tmp/ci-cluster.env
+        : > /tmp/ci-nocluster.env
+        for stack in stacks/*.yaml stacks/*.yml; do
+          [ -e "$stack" ] || continue
+          echo "Testing stack: $(basename "$stack")"
+          out="$(./run-stack.py "$stack" --dry-run --config /tmp/ci-cluster.env 2>&1)"; rc=$?
+          if [ "$rc" -eq 0 ]; then
+            echo "  ok (2-node cluster)"
+            continue
+          fi
+          echo "$out" | sed 's/^/    /'
+          if [ "$rc" -eq 3 ]; then
+            echo "  single-host (a recipe mode flag forbids distribution); retrying with no cluster"
+            ./run-stack.py "$stack" --dry-run --config /tmp/ci-nocluster.env || { echo "  FAILED (no cluster)"; exit 1; }
+            echo "  ok (single-host, no cluster)"
+          else
+            echo "  FAILED (2-node cluster)"
+            exit 1
           fi
         done

--- a/ensure-python.sh
+++ b/ensure-python.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# ensure-python.sh - Shared bootstrap sourced by run-recipe.sh and run-stack.sh.
+#
+# Locates Python 3.10+ (sets $PYTHON) and installs PyYAML if missing.
+# Exits the sourcing script with an error message if either is unavailable.
+#
+
+if command -v python3 &>/dev/null; then
+    PYTHON=python3
+elif command -v python &>/dev/null; then
+    PYTHON=python
+else
+    echo "Error: Python 3 not found. Please install Python 3.10 or later."
+    exit 1
+fi
+
+if ! $PYTHON -c 'import sys; sys.exit(sys.version_info < (3, 10))'; then
+    echo "Error: Python 3.10+ required, found $($PYTHON -c 'import sys; print("%d.%d" % sys.version_info[:2])')"
+    exit 1
+fi
+
+if ! $PYTHON -c "import yaml" 2>/dev/null; then
+    echo "Installing PyYAML..."
+    if ! $PYTHON -m pip install --quiet pyyaml; then
+        echo "Error: Failed to install PyYAML. Try: pip install pyyaml"
+        exit 1
+    fi
+fi

--- a/launch-cluster.sh
+++ b/launch-cluster.sh
@@ -20,7 +20,7 @@ fi
 ETH_IF=""
 IB_IF=""
 NCCL_DEBUG_VAL=""
-MASTER_PORT="29501"
+MASTER_PORT=""  # resolved after .env load: CLI > .env > 29501 default
 
 # Initialize variables
 NODES_ARG=""
@@ -53,6 +53,7 @@ SHM_SIZE_GB="64"
 NOFILE_LIMIT="${VLLM_SPARK_NOFILE_LIMIT:-1048576}"
 PORT_MAPPINGS=()
 VOLUME_MAPPINGS=()
+PLACEMENT_NODE=""
 ENABLE_EARLYOOM="false"
 EARLYOOM_ARGS="${VLLM_SPARK_EARLYOOM_ARGS:--M 524288,102400 -s 100 -r 60}"
 
@@ -71,6 +72,7 @@ usage() {
     echo "  --launch-script Path to bash script to execute in the container (from examples/ directory or absolute path). If launch script is specified, action should be omitted."
     echo "  --check-config  Check configuration and auto-detection without launching"
     echo "  --solo          Solo mode: skip autodetection, launch only on current node, do not launch Ray cluster"
+    echo "  --placement-node <IP>  Run the standalone container on the given node (local, or remote via SSH). Implies solo mode."
     echo "  --master-port   Port for cluster coordination: Ray head port or PyTorch distributed master port (default: 29501)"
     echo "  -p, --publish   Publish a container port in Docker format (e.g. -p 8000:8000). Solo mode only; can be specified multiple times."
     echo "  -v, --volume    Map a volume in Docker format (e.g. -v /local/path:/container/path). Can be specified multiple times."
@@ -147,6 +149,7 @@ while [[ "$#" -gt 0 ]]; do
         -v=*|--volume=*) VOLUME_MAPPINGS+=("${1#*=}") ;;
         --check-config) CHECK_CONFIG="true" ;;
         --solo) SOLO_MODE="true" ;;
+        --placement-node) PLACEMENT_NODE="$2"; shift ;;
         --ray)
             if [[ "$NO_RAY_EXPLICIT" == "true" ]]; then
                 echo "Error: --ray and --no-ray are mutually exclusive."
@@ -201,6 +204,28 @@ while [[ "$#" -gt 0 ]]; do
     esac
     shift
 done
+
+# --placement-node: run the standalone container's full lifecycle on the given
+# node (local, or remote via SSH). Implies solo mode: no Ray, no worker fan-out,
+# no master port.
+if [[ -n "$PLACEMENT_NODE" ]]; then
+    SOLO_MODE="true"
+    NODES_ARG="$PLACEMENT_NODE"
+fi
+
+# Placement-target routing: every container operation on the placement target
+# goes through run_on_target so a remote node is reached over SSH (with a
+# connect timeout so an unreachable node fails fast) and a local one runs
+# directly. Without --placement-node this always takes the local branch.
+SSH_OPTS="-o BatchMode=yes -o StrictHostKeyChecking=no -o ConnectTimeout=5"
+target_is_remote() { [[ -n "$PLACEMENT_NODE" && "$PLACEMENT_NODE" != "$LOCAL_IP" ]]; }
+run_on_target() {
+    if target_is_remote; then
+        ssh $SSH_OPTS "$PLACEMENT_NODE" "$1"
+    else
+        bash -c "$1"
+    fi
+}
 
 # Set .env file path (use default if not specified)
 if [[ -z "$CONFIG_FILE" ]]; then
@@ -299,9 +324,10 @@ if [[ -z "$IB_IF" && -n "$DOTENV_IB_IF" ]]; then
     IB_IF="$DOTENV_IB_IF"
 fi
 
-if [[ -z "$MASTER_PORT" || "$MASTER_PORT" == "29501" ]] && [[ -n "$DOTENV_MASTER_PORT" ]]; then
+if [[ -z "$MASTER_PORT" && -n "$DOTENV_MASTER_PORT" ]]; then
     MASTER_PORT="$DOTENV_MASTER_PORT"
 fi
+MASTER_PORT="${MASTER_PORT:-29501}"
 
 if [[ -z "$CONTAINER_NAME" || "$CONTAINER_NAME" == "vllm_node" ]] && [[ -n "$DOTENV_CONTAINER_NAME" ]]; then
     CONTAINER_NAME="$DOTENV_CONTAINER_NAME"
@@ -505,7 +531,12 @@ if [[ "$SOLO_MODE" == "true" ]]; then
     if [[ -z "$LOCAL_IP" ]]; then
         LOCAL_IP="127.0.0.1"
     fi
-    NODES_ARG="$LOCAL_IP"
+    if [[ -n "$PLACEMENT_NODE" ]]; then
+        NODES_ARG="$PLACEMENT_NODE"
+        echo "Placement mode enabled. Target node: $PLACEMENT_NODE"
+    else
+        NODES_ARG="$LOCAL_IP"
+    fi
     PEER_NODES=()
     echo "Solo mode enabled. Skipping node detection."
 else
@@ -527,21 +558,27 @@ if [[ "$SOLO_MODE" != "true" ]]; then
     detect_local_ip || exit 1
 fi
 
-HEAD_IP="$LOCAL_IP"
+if [[ -n "$PLACEMENT_NODE" ]]; then
+    # Placement launch: the head container runs on the placement target, which
+    # need not be the local machine. Skip the local-IP-in-nodes check.
+    HEAD_IP="$PLACEMENT_NODE"
+else
+    HEAD_IP="$LOCAL_IP"
 
-# Verify HEAD_IP is in ALL_NODES
-FOUND_HEAD=false
-for ip in "${ALL_NODES[@]}"; do
-    ip=$(echo "$ip" | xargs)
-    if [[ "$ip" == "$HEAD_IP" ]]; then
-        FOUND_HEAD=true
-        break
+    # Verify HEAD_IP is in ALL_NODES
+    FOUND_HEAD=false
+    for ip in "${ALL_NODES[@]}"; do
+        ip=$(echo "$ip" | xargs)
+        if [[ "$ip" == "$HEAD_IP" ]]; then
+            FOUND_HEAD=true
+            break
+        fi
+    done
+
+    if [ "$FOUND_HEAD" = false ]; then
+        echo "Error: Local IP ($HEAD_IP) is not in the list of nodes ($NODES_ARG)."
+        exit 1
     fi
-done
-
-if [ "$FOUND_HEAD" = false ]; then
-    echo "Error: Local IP ($HEAD_IP) is not in the list of nodes ($NODES_ARG)."
-    exit 1
 fi
 
 # Implicit Solo Mode Detection
@@ -576,17 +613,25 @@ echo "Container Name: $CONTAINER_NAME"
 echo "Image Name: $IMAGE_NAME"
 echo "Action: $ACTION"
 
-# Check SSH connectivity to worker nodes
+# Check SSH connectivity to remote nodes (placement target and/or workers)
+check_ssh_reachable() {
+    if ! ssh $SSH_OPTS "$1" true 2>/dev/null; then
+        echo "Error: Passwordless SSH to $1 failed."
+        echo "  Please ensure SSH keys are configured and the host is reachable."
+        exit 1
+    fi
+    echo "  SSH to $1: OK"
+}
+
 if [[ "$ACTION" == "start" || "$ACTION" == "exec" || "$CHECK_CONFIG" == "true" ]]; then
+    if target_is_remote; then
+        echo "Checking SSH connectivity to placement node..."
+        check_ssh_reachable "$PLACEMENT_NODE"
+    fi
     if [ ${#PEER_NODES[@]} -gt 0 ]; then
         echo "Checking SSH connectivity to worker nodes..."
         for worker in "${PEER_NODES[@]}"; do
-            if ! ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=no "$worker" true 2>/dev/null; then
-                echo "Error: Passwordless SSH to $worker failed."
-                echo "  Please ensure SSH keys are configured and the host is reachable."
-                exit 1
-            fi
-            echo "  SSH to $worker: OK"
+            check_ssh_reachable "$worker"
         done
     fi
 fi
@@ -629,9 +674,9 @@ cleanup() {
     echo ""
     echo "Stopping cluster..."
     
-    # Stop Head
+    # Stop Head (on the placement target when one is set)
     echo "Stopping head node ($HEAD_IP)..."
-    docker stop "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    run_on_target "docker stop $CONTAINER_NAME >/dev/null 2>&1" || true
     
     # Stop Workers
     for worker in "${PEER_NODES[@]}"; do
@@ -652,12 +697,12 @@ fi
 if [[ "$ACTION" == "status" ]]; then
     echo "Checking status..."
     
-    # Check Head
-    if docker ps | grep -q "$CONTAINER_NAME"; then
+    # Check Head (on the placement target when one is set)
+    if run_on_target "docker ps | grep -q '$CONTAINER_NAME'"; then
         echo "[HEAD] $HEAD_IP: Container '$CONTAINER_NAME' is RUNNING."
         if [[ "$NO_RAY_MODE" == "false" ]]; then
             echo "--- Ray Status ---"
-            docker exec "$CONTAINER_NAME" ray status || echo "Failed to get ray status."
+            run_on_target "docker exec $CONTAINER_NAME ray status" || echo "Failed to get ray status."
             echo "------------------"
         fi
     else
@@ -685,8 +730,8 @@ fi
 check_cluster_running() {
     local running=false
     
-    # Check Head
-    if docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+    # Check Head (on the placement target when one is set)
+    if run_on_target "docker ps --format '{{.Names}}' | grep -q '^${CONTAINER_NAME}$'"; then
         echo "Warning: Container '$CONTAINER_NAME' is already running on head node ($HEAD_IP)."
         running=true
     fi
@@ -1081,15 +1126,13 @@ start_cluster() {
     local keepalive_cmd
     keepalive_cmd="$(container_keepalive_command)"
 
-    # Start Head Node
+    # Start Head Node (run_on_target reaches the placement target when one is
+    # set, and runs locally otherwise)
     echo "Starting Head Node on $HEAD_IP..."
     if [[ "$MOUNT_CACHE_DIRS" == "true" ]]; then
-        for dir in "${CACHE_DIRS_TO_CREATE[@]}"; do
-            mkdir -p "$dir"
-        done
+        run_on_target "mkdir -p ${CACHE_DIRS_TO_CREATE[*]}"
     fi
-    docker run $docker_caps_args $docker_resource_args \
-        $(get_env_flags "$HEAD_IP") $docker_args_common $keepalive_cmd
+    run_on_target "docker run $docker_caps_args $docker_resource_args $(get_env_flags "$HEAD_IP") $docker_args_common $keepalive_cmd"
 
     # Start Worker Nodes
     for worker in "${PEER_NODES[@]}"; do
@@ -1101,11 +1144,14 @@ start_cluster() {
         ssh "$worker" "$docker_run_cmd $keepalive_cmd"
     done
 
-    # Apply mods (containers are idle — no mod_done sync needed)
+    # Apply mods (containers are idle — no mod_done sync needed). HEAD_IP is
+    # the placement target when one is set, so only the is-local flag varies.
     if [[ ${#MOD_PATHS[@]} -gt 0 ]]; then
         echo "Applying modifications to cluster nodes..."
+        local head_is_local="true"
+        if target_is_remote; then head_is_local="false"; fi
         for i in "${!MOD_PATHS[@]}"; do
-            apply_mod_to_container "$HEAD_IP" "$CONTAINER_NAME" "true" "${MOD_PATHS[$i]}" "${MOD_TYPES[$i]}"
+            apply_mod_to_container "$HEAD_IP" "$CONTAINER_NAME" "$head_is_local" "${MOD_PATHS[$i]}" "${MOD_TYPES[$i]}"
         done
         for worker in "${PEER_NODES[@]}"; do
             for i in "${!MOD_PATHS[@]}"; do
@@ -1139,7 +1185,11 @@ start_cluster() {
                     temp_ray_script="$ray_script"
                 fi
             fi
-            copy_script_to_container "$CONTAINER_NAME" "$ray_script" "head node"
+            if target_is_remote; then
+                copy_script_to_worker "$PLACEMENT_NODE" "$CONTAINER_NAME" "$ray_script"
+            else
+                copy_script_to_container "$CONTAINER_NAME" "$ray_script" "head node"
+            fi
             [[ -n "$temp_ray_script" ]] && rm -f "$temp_ray_script"
         fi
     fi
@@ -1179,16 +1229,36 @@ wait_for_cluster() {
     exit 1
 }
 
-# Execute command on head node (daemon or interactive)
+# Execute command on head node (daemon or interactive).
+# When a remote placement target is set, the docker exec runs there over SSH.
 _exec_on_head() {
-    local cmd="$1"
+    local cmd="$1" exec_flags ssh_flags="" payload
     if [[ "$DAEMON_MODE" == "true" ]]; then
-        docker exec -d "$CONTAINER_NAME" bash -c "$cmd >> /proc/1/fd/1 2>&1"
-        echo "Command dispatched in background (Daemon mode). Container: $CONTAINER_NAME"
+        exec_flags="-d"
+        payload="$cmd >> /proc/1/fd/1 2>&1"
+    elif [ -t 0 ]; then
+        exec_flags="-it"
+        ssh_flags="-t"
+        payload="$cmd"
     else
-        if [ -t 0 ]; then DOCKER_EXEC_FLAGS="-it"; else DOCKER_EXEC_FLAGS="-i"; fi
-        docker exec $DOCKER_EXEC_FLAGS "$CONTAINER_NAME" bash -c "$cmd"
+        exec_flags="-i"
+        payload="$cmd"
     fi
+    local rc on_where=""
+    if target_is_remote; then
+        local remote_cmd
+        printf -v remote_cmd 'docker exec %s %q bash -c %q' "$exec_flags" "$CONTAINER_NAME" "$payload"
+        ssh $ssh_flags $SSH_OPTS "$PLACEMENT_NODE" "$remote_cmd"
+        rc=$?
+        on_where=" on $PLACEMENT_NODE"
+    else
+        docker exec $exec_flags "$CONTAINER_NAME" bash -c "$payload"
+        rc=$?
+    fi
+    if [[ "$DAEMON_MODE" == "true" ]]; then
+        echo "Command dispatched in background (Daemon mode). Container: $CONTAINER_NAME$on_where"
+    fi
+    return $rc
 }
 
 # Execute a no-ray multi-node command: workers (background) then head
@@ -1282,7 +1352,7 @@ elif [[ "$ACTION" == "start" ]]; then
     else
         echo "Cluster started. Tailing logs from head node..."
         echo "Press Ctrl+C to stop the cluster."
-        docker logs -f "$CONTAINER_NAME" &
+        run_on_target "docker logs -f $CONTAINER_NAME" &
         wait $!
     fi
 fi

--- a/run-recipe.py
+++ b/run-recipe.py
@@ -86,6 +86,7 @@ RELATED FILES:
 import argparse
 import os
 import re
+import socket
 import subprocess
 import shlex
 import sys
@@ -130,6 +131,29 @@ def ensure_ray_backend(command: str) -> str:
 
 
 
+def resolve_recipe_path(recipe_path: Path) -> Path | None:
+    """Resolve a recipe reference to an existing file, or None if not found.
+
+    Search order: exact path -> path with .yaml/.yml appended -> recipes/
+    directory (bare name, name with .yaml/.yml, then stem with .yaml).
+    Shared with run-stack.py so both drivers accept the same references.
+    """
+    if recipe_path.exists():
+        return recipe_path
+    candidates = [
+        Path(str(recipe_path) + ".yaml"),
+        Path(str(recipe_path) + ".yml"),
+        RECIPES_DIR / recipe_path.name,
+        RECIPES_DIR / f"{recipe_path.name}.yaml",
+        RECIPES_DIR / f"{recipe_path.name}.yml",
+        RECIPES_DIR / f"{recipe_path.stem}.yaml",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
+
+
 def load_recipe(recipe_path: Path) -> dict[str, Any]:
     """
     Load and validate a recipe YAML file.
@@ -167,25 +191,12 @@ def load_recipe(recipe_path: Path) -> dict[str, Any]:
     Raises:
         SystemExit: If recipe not found or validation fails
     """
-    if not recipe_path.exists():
-        # Try candidates in order: add extension to original path first,
-        # then fall back to flat recipes/ directory (for bare recipe names)
-        candidates = [
-            Path(str(recipe_path) + ".yaml"),
-            Path(str(recipe_path) + ".yml"),
-            RECIPES_DIR / recipe_path.name,
-            RECIPES_DIR / f"{recipe_path.name}.yaml",
-            RECIPES_DIR / f"{recipe_path.name}.yml",
-            RECIPES_DIR / f"{recipe_path.stem}.yaml",
-        ]
-        for candidate in candidates:
-            if candidate.exists():
-                recipe_path = candidate
-                break
-        else:
-            print(f"Error: Recipe not found: {recipe_path}")
-            print(f"Searched in: {recipe_path}, {RECIPES_DIR}")
-            sys.exit(1)
+    resolved = resolve_recipe_path(recipe_path)
+    if resolved is None:
+        print(f"Error: Recipe not found: {recipe_path}")
+        print(f"Searched in: {recipe_path}, {RECIPES_DIR}")
+        sys.exit(1)
+    recipe_path = resolved
 
     with open(recipe_path) as f:
         recipe = yaml.safe_load(f)
@@ -564,15 +575,13 @@ def get_worker_nodes(nodes: list[str]) -> list[str]:
     return nodes[1:]
 
 
-def load_env_file() -> dict[str, str]:
+def load_env_file(path: Path | None = None) -> dict[str, str]:
     """
-    Load environment variables from .env file.
+    Load environment variables from a .env file.
 
-    Reads the .env file created by --discover for persistent cluster configuration.
-
-    EXTENSIBILITY:
-    - To support multiple .env files: Add a --env-file CLI argument
-    - To add validation: Check for required keys after loading
+    Reads the .env file created by --discover for persistent cluster
+    configuration. Defaults to this run's ENV_FILE; run-stack.py passes an
+    explicit path so both drivers share one parser.
 
     SUPPORTED KEYS (set by --discover):
         CLUSTER_NODES: Comma-separated list of node IPs
@@ -581,11 +590,13 @@ def load_env_file() -> dict[str, str]:
         IB_IF: InfiniBand interface name (if available)
 
     Returns:
-        Dictionary of key=value pairs from .env file
+        Dictionary of key=value pairs from the .env file
     """
+    if path is None:
+        path = ENV_FILE
     env = {}
-    if ENV_FILE.exists():
-        with open(ENV_FILE) as f:
+    if path is not None and path.exists():
+        with open(path) as f:
             for line in f:
                 line = line.strip()
                 if line and not line.startswith("#") and "=" in line:
@@ -594,6 +605,34 @@ def load_env_file() -> dict[str, str]:
                     value = value.strip().strip('"').strip("'")
                     env[key.strip()] = value
     return env
+
+
+def is_local_address(ip):
+    """True if `ip` names this machine — via .env LOCAL_IP or the host's own
+    network addresses. Used to skip a needless self-copy for a local placement
+    when .env has no LOCAL_IP (the fresh-node case --placement-node serves)."""
+    if not ip:
+        return False
+    if load_env_file().get("LOCAL_IP") == ip:
+        return True
+    if ip in ("127.0.0.1", "localhost", "::1"):
+        return True
+    try:
+        for info in socket.getaddrinfo(socket.gethostname(), None):
+            if info[4][0] == ip:
+                return True
+    except OSError:
+        pass
+    # getaddrinfo(hostname) commonly resolves to just 127.0.1.1 on
+    # Debian-family hosts, missing the LAN address. A UDP "connect" (no packet
+    # is sent) asks the kernel which source address routes to `ip`; it equals
+    # `ip` only when the address is one of this machine's own.
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect((ip, 9))
+            return s.getsockname()[0] == ip
+    except OSError:
+        return False
 
 
 def run_autodiscover() -> dict[str, str] | None:
@@ -686,6 +725,11 @@ Examples:
   # Cluster deployment (auto-discover)
   %(prog)s --discover              # Detect nodes and save to .env
   %(prog)s glm-4.7-nvfp4 --setup   # Uses nodes from .env
+
+  # Pin as a standalone server on one node (local or remote), no Ray/cluster
+  # coordination -- implies solo. Used by run-stack.py for per-recipe
+  # 'placement: <IP>' entries; useful directly too.
+  %(prog)s glm-4.7-nvfp4 --placement-node 192.168.1.1 --setup
 
   # Just build/download without running
   %(prog)s glm-4.7-nvfp4 --build-only
@@ -858,6 +902,10 @@ Examples:
         help="Port for cluster coordination (Ray head port or PyTorch distributed master port, default: 29501)",
     )
     launch_group.add_argument(
+        "--placement-node", dest="placement_node", metavar="IP",
+        help="Run this recipe as a standalone server on one node (local or remote). Implies solo.",
+    )
+    launch_group.add_argument(
         "--name",
         dest="container_name",
         help="Override container name (default: vllm_node)",
@@ -1020,13 +1068,16 @@ Examples:
     model = recipe.get("model")
     build_args = recipe.get("build_args", [])
 
+    # A pinned placement node forces a solo run: no node list, no autodiscover.
+    placement_solo = args.solo or bool(args.placement_node)
+
     # Parse nodes - check command line first, then .env file, then autodiscover
-    nodes = parse_nodes(args.nodes) if not args.solo else []
+    nodes = parse_nodes(args.nodes) if not placement_solo else []
     nodes_from_env = False
     eth_if = None
     ib_if = None
 
-    if not args.solo:
+    if not placement_solo:
         # Try to load from .env file
         env = load_env_file()
         if not nodes:
@@ -1062,7 +1113,7 @@ Examples:
     # Check if recipe requires cluster mode
     cluster_only = recipe.get("cluster_only", False)
     solo_only = recipe.get("solo_only", False)
-    is_solo = args.solo or not is_cluster
+    is_solo = placement_solo or not is_cluster
 
     use_ray = getattr(args, "ray", False) and not is_solo
 
@@ -1119,6 +1170,12 @@ Examples:
             copy_targets = [h.strip() for h in copy_hosts_str.split(",") if h.strip()]
         else:
             copy_targets = worker_nodes
+    elif args.placement_node:
+        # A placement run targets a single (possibly remote) node. Direct the
+        # --setup image/weight copy there instead of the (empty) cluster list.
+        # A placement run copies image/weights to the target only if it is NOT
+        # this machine. Robust to a missing .env LOCAL_IP (see is_local_address).
+        copy_targets = None if is_local_address(args.placement_node) else [args.placement_node]
     else:
         copy_targets = None
 
@@ -1322,6 +1379,8 @@ Examples:
             cmd_parts.append("--no-ray")
         if nodes:
             cmd_parts.extend(["-n", ",".join(nodes)])
+        if args.placement_node:
+            cmd_parts.extend(["--placement-node", args.placement_node])
         if args.nccl_debug:
             cmd_parts.extend(["--nccl-debug", args.nccl_debug])
         for env_var in args.env_vars:
@@ -1409,6 +1468,9 @@ Examples:
         # Pass nodes to launch-cluster.sh (from command line, .env, or autodiscover)
         if nodes:
             cmd.extend(["-n", ",".join(nodes)])
+
+        if args.placement_node:
+            cmd.extend(["--placement-node", args.placement_node])
 
         if args.nccl_debug:
             cmd.extend(["--nccl-debug", args.nccl_debug])

--- a/run-recipe.sh
+++ b/run-recipe.sh
@@ -6,37 +6,7 @@
 #
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-RECIPE_SCRIPT="$SCRIPT_DIR/run-recipe.py"
 
-# Check for Python 3.10+
-if command -v python3 &>/dev/null; then
-    PYTHON=python3
-elif command -v python &>/dev/null; then
-    PYTHON=python
-else
-    echo "Error: Python 3 not found. Please install Python 3.10 or later."
-    exit 1
-fi
+source "$SCRIPT_DIR/ensure-python.sh"
 
-# Verify version
-PY_VERSION=$($PYTHON -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
-PY_MAJOR=$($PYTHON -c 'import sys; print(sys.version_info.major)')
-PY_MINOR=$($PYTHON -c 'import sys; print(sys.version_info.minor)')
-
-if [[ "$PY_MAJOR" -lt 3 ]] || [[ "$PY_MAJOR" -eq 3 && "$PY_MINOR" -lt 10 ]]; then
-    echo "Error: Python 3.10+ required, found $PY_VERSION"
-    exit 1
-fi
-
-# Check for PyYAML and install if missing
-if ! $PYTHON -c "import yaml" 2>/dev/null; then
-    echo "Installing PyYAML..."
-    $PYTHON -m pip install --quiet pyyaml
-    if [[ $? -ne 0 ]]; then
-        echo "Error: Failed to install PyYAML. Try: pip install pyyaml"
-        exit 1
-    fi
-fi
-
-# Run the recipe script
-exec $PYTHON "$RECIPE_SCRIPT" "$@"
+exec $PYTHON "$SCRIPT_DIR/run-recipe.py" "$@"

--- a/run-stack.py
+++ b/run-stack.py
@@ -1,0 +1,861 @@
+#!/usr/bin/env python3
+"""
+run-stack.py - Serve multiple vLLM recipes at once, each with its own placement.
+
+A "stack" is a declarative YAML manifest (see stacks/*.yaml) listing several
+recipes to serve at once, each in its own Docker container on its own port —
+distributed across the cluster or pinned to a single node, per recipe. This
+driver is a thin layer on top of run-recipe.py: it launches each recipe in the
+listed order (which MUST be descending memory usage) and waits for each
+recipe's /health endpoint to report ready before starting the next one.
+
+Why the order and the health gate matter: vLLM profiles free memory at startup,
+so the largest model must claim its slice against a clean pool first (and fail
+fast if it won't fit). Health-gating each launch also serializes first-time
+kernel compilation so co-located instances don't race on the shared compile
+caches.
+
+Scope: each recipe in a stack picks its own placement via a per-recipe
+`placement:` key: 'all' distributes it across the cluster in .env's
+CLUSTER_NODES (or runs it solo on this host when CLUSTER_NODES has fewer than
+two nodes), or a single node IP pins it alone to that host -- this machine or
+a remote one. A recipe with no 'placement:' defaults to 'all'. Every
+distributed entry gets its own auto-assigned --master-port (base .env
+MASTER_PORT, else 29501, plus the entry index; an explicit master_port:
+overrides) so co-located distributed recipes don't collide.
+
+Usage:
+    ./run-stack.sh <stack> [--setup] [--dry-run] [--config FILE]
+                                                    # bring the stack up
+    ./run-stack.sh <stack> --status                # show each container + health
+    ./run-stack.sh <stack> --stop                  # tear the whole stack down
+
+Exit codes: 0 success, 1 error, 3 a recipe's cluster_only/solo_only flag
+contradicts its resolved placement (CI keys on 3 to retry without a cluster).
+"""
+
+import argparse
+import collections
+import importlib.util
+import re
+import shlex
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import yaml
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+RUN_RECIPE = SCRIPT_DIR / "run-recipe.py"
+LAUNCH_CLUSTER = SCRIPT_DIR / "launch-cluster.sh"
+STACKS_DIR = SCRIPT_DIR / "stacks"
+RECIPES_DIR = SCRIPT_DIR / "recipes"
+
+# run-recipe.py as a module (the hyphenated filename rules out a plain import):
+# shares its .env parser, node-list parser, and recipe-path resolution so the
+# two drivers cannot drift on what a recipe reference or .env line means.
+_spec = importlib.util.spec_from_file_location("run_recipe", RUN_RECIPE)
+assert _spec is not None and _spec.loader is not None
+run_recipe = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(run_recipe)
+
+# Exit code for a cluster_only/solo_only recipe whose resolved placement
+# contradicts it; CI retries such stacks without a cluster (see validate_modes).
+EXIT_MODE_CONFLICT = 3
+
+DEFAULT_HEALTH_TIMEOUT = 1200  # seconds to wait for a recipe to become ready
+HEALTH_POLL_INTERVAL = 5       # seconds between /health polls
+STATE_CHECK_EVERY = 6          # health polls between container-state probes
+DEFAULT_PORT = 8000
+DEFAULT_MASTER_PORT = 29501    # auto-assign base when .env sets no MASTER_PORT
+STACK_VERSIONS = ("1",)        # manifest versions this driver understands
+
+# Docker's accepted container-name charset.
+CONTAINER_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
+# Characters in a 'volumes:' mapping that would not survive launch-cluster.sh's
+# unquoted $DOCKER_ARGS expansion and its bash -c / ssh re-parse of the docker
+# command line: whitespace word-splits, the rest are shell syntax or globs.
+VOLUME_UNSAFE_RE = re.compile(r"""[\s$`;&|<>()'"\\*?\[\]{}]""")
+
+# A resolved per-entry placement.
+#   kind:      "distributed" | "single"
+#   nodes:     distributed -> full cluster node list; single -> [] (unused)
+#   host:      distributed -> None (API binds on the head/localhost)
+#              single, this machine -> None (localhost)
+#              single, remote node  -> the node IP string
+#              (so a non-None host <=> the entry runs on a remote node)
+#   source:    short human-readable reason, for banner + error messages
+Placement = collections.namedtuple("Placement", "kind nodes host source")
+
+
+# --------------------------------------------------------------------------- #
+# Manifest loading / resolution
+# --------------------------------------------------------------------------- #
+def resolve_stack_path(name_or_path):
+    """Resolve a stack manifest by path or by name under stacks/."""
+    candidates = [
+        Path(name_or_path),
+        STACKS_DIR / name_or_path,
+        STACKS_DIR / f"{name_or_path}.yaml",
+        STACKS_DIR / f"{name_or_path}.yml",
+    ]
+    for c in candidates:
+        if c.is_file():
+            return c.resolve()
+    raise FileNotFoundError(
+        f"Stack manifest '{name_or_path}' not found. Looked in: "
+        + ", ".join(str(c) for c in candidates)
+    )
+
+
+def read_recipe_meta(recipe_path):
+    """Read the recipe fields run-stack cares about: port and mode flags.
+
+    Deliberately does NOT swallow parse errors: the mode flags gate
+    validate_modes, so a recipe that cannot be parsed must not be silently
+    treated as having no mode restriction.
+    """
+    data = yaml.safe_load(recipe_path.read_text()) or {}
+    if not isinstance(data, dict):
+        # Raise a yaml error so the call site's "could not be read" wrapper
+        # converts it: a recipe whose top level is a list/scalar is just as
+        # unreadable for our purposes as one that doesn't parse at all.
+        raise yaml.YAMLError(
+            f"top-level YAML is a {type(data).__name__}, not a mapping"
+        )
+    return {
+        "port": (data.get("defaults") or {}).get("port", DEFAULT_PORT),
+        "cluster_only": bool(data.get("cluster_only", False)),
+        "solo_only": bool(data.get("solo_only", False)),
+    }
+
+
+def sanitize_name(recipe):
+    """Derive a Docker-safe default container name from a recipe name."""
+    base = Path(recipe).name
+    # Strip only a manifest extension: Path.stem would truncate dotted recipe
+    # names like 'qwen3.6-35b-a3b-nvfp4' to 'qwen3'.
+    for ext in (".yaml", ".yml"):
+        if base.endswith(ext):
+            base = base[: -len(ext)]
+            break
+    cleaned = "".join(c if (c.isalnum() or c in "_.-") else "_" for c in base)
+    return cleaned or "vllm_node"
+
+
+def resolve_placement(raw_placement, env, config_path):
+    """Resolve one entry's placement. 'all' -> distributed across CLUSTER_NODES
+    (or solo-local if none). '<IP>' -> single node: local (host=None) if it is
+    this machine, else that remote node. An IP must be a configured node or
+    LOCAL_IP."""
+    if raw_placement is not None and not isinstance(raw_placement, str):
+        raise ValueError(
+            f"'placement' must be 'all' or a single node-IP string, got "
+            f"{raw_placement!r}. Arbitrary node subsets are not supported; use "
+            "'all' or one IP from CLUSTER_NODES."
+        )
+    raw = (raw_placement or "all").strip()
+    local = env.get("LOCAL_IP")
+    cluster = run_recipe.parse_nodes(env.get("CLUSTER_NODES"))
+    if raw == "all":
+        # Distinguish an explicit 'placement: all' from the default: quoting a
+        # key the manifest never set sends the reader hunting for it.
+        how = "placement: all" if raw_placement is not None else "default placement: all"
+        if len(cluster) > 1:
+            return Placement("distributed", cluster, None, f"{how}, cluster from {config_path}")
+        return Placement(
+            "single", [], None, f"{how}, fewer than two cluster nodes configured"
+        )
+    if local and raw == local:
+        return Placement("single", [], None, f"placement: {raw} (this host)")
+    if raw in cluster:
+        return Placement("single", [], raw, f"placement: {raw}")
+    raise ValueError(
+        f"placement '{raw}' is neither this host (LOCAL_IP={local!r}) nor one of "
+        f"the configured cluster nodes ({', '.join(cluster) or 'none'}). "
+        "Use 'all' or an IP from CLUSTER_NODES."
+    )
+
+
+def entry_host(entry, default_host):
+    """Host to poll for /health: the placement node, else the default (localhost)."""
+    p = entry["placement"]
+    return p.host if p.host else default_host
+
+
+def entry_container_state(entry):
+    """Docker state of an entry's container, wherever it runs. Local for
+    distributed/local placements, over ssh for a remote placement. Returns a
+    docker state string, 'unreachable', or None (absent)."""
+    p = entry["placement"]
+    if p.host:
+        return remote_container_state(p.host, entry["container_name"])
+    return container_state(entry["container_name"])
+
+
+def split_head_workers(nodes, env):
+    """Partition nodes into (head, workers).
+
+    launch-cluster.sh sets HEAD_IP to the local IP and requires it to appear
+    somewhere in the node list. The head is therefore whichever configured
+    node is THIS machine -- NOT nodes[0]. Returns (None, nodes) when LOCAL_IP
+    is unknown, so callers degrade honestly instead of mislabelling a worker
+    as the head.
+    """
+    local = env.get("LOCAL_IP")
+    if local and local in nodes:
+        return local, [n for n in nodes if n != local]
+    return None, list(nodes)
+
+
+def print_placement_summary(stack):
+    for entry in stack["entries"]:
+        p = entry["placement"]
+        if p.kind == "distributed":
+            where = f"distributed across {len(p.nodes)} nodes"
+        elif p.host is None:
+            where = "this host"
+        else:
+            where = f"node {p.host}"
+        print(f"  {entry['recipe']:40s} {entry['container_name']:18s} -> {where}")
+    # No banner when 'all' resolves solo for want of a cluster: 'all' means
+    # every node available, so on a single-node host -- the common case -- it
+    # is the expected placement, identical to pinning LOCAL_IP. The per-entry
+    # lines above already name the target, and a cluster_only recipe in that
+    # position is refused outright by validate_modes on the launch paths.
+
+
+def placement_api_node(entry, env):
+    """The node token an entry's API server binds on (for per-node uniqueness).
+    Distributed workers are --headless, so a distributed entry's API is on the
+    head; a local single placement is also the head; a remote single placement
+    is its own node."""
+    return entry["placement"].host or env.get("LOCAL_IP") or "local"
+
+
+def parse_int_field(value, field, path, entry_no):
+    """Validate an integer port-valued manifest field, rejecting YAML booleans
+    (which are ints to Python: 'port: true' would become --port 1)."""
+    if isinstance(value, bool):
+        raise ValueError(
+            f"Stack '{path}': entry #{entry_no}: '{field}' must be an integer, "
+            f"got the YAML boolean {value!r}."
+        )
+    try:
+        value = int(value)
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"Stack '{path}': entry #{entry_no}: '{field}' must be an integer, "
+            f"got {value!r}."
+        ) from None
+    if not 1 <= value <= 65535:
+        raise ValueError(
+            f"Stack '{path}': entry #{entry_no}: '{field}' must be between "
+            f"1 and 65535, got {value}."
+        )
+    return value
+
+
+def parse_volume_field(value, path, entry_no):
+    """Validate one 'volumes:' mapping and resolve a relative host path.
+
+    Docker syntax is host:container[:options]. A bare host token with no '/'
+    is a *named volume* to Docker (volume names cannot contain '/'), so it is
+    left alone. A relative path is resolved against the repo root, as 'mods:'
+    are: Docker would otherwise resolve it against the caller's cwd, making the
+    mount depend on where run-stack happened to be invoked from.
+
+    The container path must be absolute -- Docker rejects a relative one, and
+    catching it here beats discovering it mid-launch on a remote node. The same
+    reasoning covers shell metacharacters: launch-cluster.sh expands the mapping
+    unquoted inside $DOCKER_ARGS and re-parses the docker line through bash -c
+    (and ssh for a remote node), so whitespace would word-split and '$' or ';'
+    would execute rather than mount.
+    """
+    if not isinstance(value, str):
+        raise ValueError(
+            f"Stack '{path}': entry #{entry_no}: 'volumes' entries must be "
+            f"strings in Docker's host:container[:options] form, got {value!r}."
+        )
+    if VOLUME_UNSAFE_RE.search(value):
+        raise ValueError(
+            f"Stack '{path}': entry #{entry_no}: volume {value!r} contains "
+            "whitespace or a shell metacharacter, which would not survive the "
+            "docker command line. Use a path without them."
+        )
+    parts = value.split(":")
+    if len(parts) < 2 or not parts[0] or not parts[1]:
+        raise ValueError(
+            f"Stack '{path}': entry #{entry_no}: volume {value!r} must be in "
+            "Docker's host:container[:options] form."
+        )
+    host, container = parts[0], parts[1]
+    if not container.startswith("/"):
+        raise ValueError(
+            f"Stack '{path}': entry #{entry_no}: volume {value!r} has container "
+            f"path {container!r}, which must be absolute (start with '/')."
+        )
+    if host.startswith("~"):
+        try:
+            host = str(Path(host).expanduser())
+        except RuntimeError:
+            # expanduser() raises when ~user names an account with no home.
+            raise ValueError(
+                f"Stack '{path}': entry #{entry_no}: volume {value!r} has host "
+                f"path {host!r}, whose home directory could not be resolved."
+            ) from None
+    elif "/" in host and not Path(host).is_absolute():
+        host = str((SCRIPT_DIR / host).resolve())
+    return ":".join([host, container, *parts[2:]])
+
+
+def is_distributed(entry):
+    return entry["placement"].kind == "distributed"
+
+
+def load_stack(name_or_path, master_base, env, config_path):
+    """Load and normalize a stack manifest into a list of resolved entries."""
+    path = resolve_stack_path(name_or_path)
+    data = yaml.safe_load(path.read_text()) or {}
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"Stack '{path}': top-level YAML must be a mapping "
+            f"(got a {type(data).__name__})."
+        )
+
+    version = data.get("stack_version")
+    if version is not None and str(version) not in STACK_VERSIONS:
+        raise ValueError(
+            f"Stack '{path}': unsupported stack_version {version!r} "
+            f"(supported: {', '.join(STACK_VERSIONS)})."
+        )
+    if "solo_only" in data:
+        print(
+            f"Warning: stack '{path}': top-level 'solo_only' is no longer "
+            "supported and is ignored; use per-recipe 'placement:' instead.",
+            file=sys.stderr,
+        )
+
+    raw_entries = data.get("recipes")
+    if not raw_entries:
+        raise ValueError(f"Stack '{path}' has no 'recipes:' list.")
+    if not isinstance(raw_entries, list):
+        raise ValueError(f"Stack '{path}': 'recipes:' must be a list.")
+
+    entries = []
+    seen_names = {}
+    for i, raw in enumerate(raw_entries):
+        if isinstance(raw, str):
+            raw = {"recipe": raw}
+        if not isinstance(raw, dict) or not raw.get("recipe"):
+            raise ValueError(
+                f"Stack '{path}': entry #{i + 1} must have a 'recipe' field."
+            )
+        recipe = raw["recipe"]
+        recipe_path = run_recipe.resolve_recipe_path(Path(recipe))
+        if recipe_path is None:
+            raise ValueError(
+                f"Stack '{path}': entry #{i + 1}: recipe '{recipe}' not found "
+                f"(looked for a file at that path and under {RECIPES_DIR}/)."
+            )
+        explicit_name = raw.get("container_name")
+        cname = explicit_name or sanitize_name(recipe)
+        if not CONTAINER_NAME_RE.match(cname):
+            derived = (
+                "" if explicit_name
+                else f" (derived from recipe '{recipe}'; set 'container_name' explicitly)"
+            )
+            raise ValueError(
+                f"Stack '{path}': entry #{i + 1}: container_name '{cname}' is not "
+                "a valid Docker container name "
+                f"(must match [a-zA-Z0-9][a-zA-Z0-9_.-]*){derived}."
+            )
+        try:
+            meta = read_recipe_meta(recipe_path)
+        except (OSError, yaml.YAMLError) as e:
+            raise ValueError(
+                f"Stack '{path}': entry #{i + 1}: recipe '{recipe}' could not be "
+                f"read ({type(e).__name__}). A recipe that cannot be parsed "
+                "cannot be checked for cluster_only/solo_only, so this stack is "
+                "refused rather than launched with unknown mode requirements."
+            ) from None
+        port = raw.get("port")
+        if port is None:
+            port = meta["port"]
+        port = parse_int_field(port, "port", path, i + 1)
+
+        if cname in seen_names:
+            raise ValueError(
+                f"Stack '{path}': duplicate container_name '{cname}' "
+                f"(entries #{seen_names[cname] + 1} and #{i + 1}). "
+                "Set an explicit 'container_name' for one of them."
+            )
+        seen_names[cname] = i
+
+        raw_mp = raw.get("master_port")
+        if raw_mp is None:
+            master_port = master_base + i
+        else:
+            # The range check matters: run-recipe.py drops a falsy
+            # --master-port entirely, so 0 would silently fall back to the
+            # 29501 default and collide with the entry using it.
+            master_port = parse_int_field(raw_mp, "master_port", path, i + 1)
+        try:
+            placement = resolve_placement(raw.get("placement"), env, config_path)
+        except ValueError as e:
+            raise ValueError(f"Stack '{path}': entry #{i + 1} ('{recipe}'): {e}") from None
+
+        # Resolve mod paths relative to the repo root so run-recipe.py's
+        # cwd-relative resolution doesn't depend on where run-stack is invoked.
+        mods = []
+        for m in raw.get("mods", []) or []:
+            mp = Path(m)
+            mods.append(str(mp if mp.is_absolute() else (SCRIPT_DIR / mp)))
+
+        raw_volumes = raw.get("volumes") or []
+        if not isinstance(raw_volumes, list):
+            raise ValueError(
+                f"Stack '{path}': entry #{i + 1}: 'volumes' must be a list of "
+                f"host:container[:options] strings, got {raw_volumes!r}."
+            )
+        volumes = [parse_volume_field(v, path, i + 1) for v in raw_volumes]
+
+        entries.append(
+            {
+                "recipe": recipe,
+                "container_name": cname,
+                "port": port,
+                "master_port": master_port,
+                "gpu_mem": raw.get("gpu_mem"),
+                "mods": mods,
+                "volumes": volumes,
+                "extra_args": [str(a) for a in (raw.get("extra_args") or [])],
+                "cluster_only": meta["cluster_only"],
+                "solo_only": meta["solo_only"],
+                "placement": placement,
+            }
+        )
+
+    node_ports = {}
+    for i, entry in enumerate(entries):
+        node = placement_api_node(entry, env)
+        key = (node, entry["port"])
+        if key in node_ports:
+            raise ValueError(
+                f"Stack '{path}': entry #{i + 1}: port {entry['port']} on node "
+                f"{node} is already used by entry #{node_ports[key] + 1}. Ports "
+                "must be unique per node.")
+        node_ports[key] = i
+
+    dist_mports = {}
+    for i, entry in enumerate(entries):
+        if not is_distributed(entry):
+            continue
+        mp = entry["master_port"]
+        if mp in dist_mports:
+            raise ValueError(
+                f"Stack '{path}': entry #{i + 1}: master_port {mp} duplicates "
+                f"entry #{dist_mports[mp] + 1}. Distributed recipes share the head, "
+                "so each needs a distinct coordination port.")
+        dist_mports[mp] = i
+
+    head = env.get("LOCAL_IP") or "local"
+    head_api_ports = {e["port"] for e in entries if placement_api_node(e, env) == head}
+    for i, entry in enumerate(entries):
+        if is_distributed(entry) and entry["master_port"] in head_api_ports:
+            raise ValueError(
+                f"Stack '{path}': entry #{i + 1}: master_port {entry['master_port']} "
+                "collides with an API port on the head node.")
+
+    raw_timeout = data.get("health_timeout", DEFAULT_HEALTH_TIMEOUT)
+    try:
+        health_timeout = int(raw_timeout)
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"Stack '{path}': 'health_timeout' must be an integer (seconds), "
+            f"got {raw_timeout!r}."
+        ) from None
+
+    return {
+        "path": path,
+        "name": data.get("name", path.stem),
+        "health_timeout": health_timeout,
+        "entries": entries,
+    }
+
+
+class ModeConflictError(ValueError):
+    """A recipe's cluster_only/solo_only flag contradicts its resolved
+    placement. Reported with EXIT_MODE_CONFLICT so CI can tell 'this stack is
+    legitimately single-host' apart from a genuinely broken manifest."""
+
+
+def validate_modes(stack):
+    """Reject recipes whose mode requirement contradicts their resolved placement."""
+    for i, entry in enumerate(stack["entries"], 1):
+        p = entry["placement"]
+        if entry["cluster_only"] and p.kind == "single":
+            raise ModeConflictError(
+                f"Stack '{stack['path']}': entry #{i}: recipe '{entry['recipe']}' "
+                f"is cluster_only, but its placement resolved to a single node "
+                f"({p.source}). Use 'placement: all' with a configured cluster.")
+        if entry["solo_only"] and p.kind == "distributed":
+            raise ModeConflictError(
+                f"Stack '{stack['path']}': entry #{i}: recipe '{entry['recipe']}' "
+                f"is solo_only, but its placement resolved to distributed "
+                f"({p.source}). Pin it with 'placement: <node-IP>'.")
+
+
+# --------------------------------------------------------------------------- #
+# Command construction
+# --------------------------------------------------------------------------- #
+def placement_flags(entry):
+    """Placement -> CLI flags, shared by launch (run-recipe.py) and stop
+    (launch-cluster.sh) so the two cannot diverge. A distributed entry must
+    pass -n and NEVER --solo: --solo skips launch-cluster.sh's ssh worker
+    loop, which on stop would strand worker containers."""
+    p = entry["placement"]
+    if p.kind == "distributed":
+        return ["-n", ",".join(p.nodes)]
+    if p.host is None:
+        return ["--solo"]
+    return ["--placement-node", p.host]
+
+
+def recipe_args(entry, setup, config_path=None, daemon=True):
+    """Args to run-recipe.py for one entry (everything after the program name)."""
+    args = [entry["recipe"], *placement_flags(entry)]
+    if is_distributed(entry):
+        args += ["--master-port", str(entry["master_port"])]
+    args += ["--name", entry["container_name"]]
+    if daemon:
+        args.append("-d")
+    args += ["--port", str(entry["port"])]
+    if entry["gpu_mem"] is not None:
+        args += ["--gpu-mem", str(entry["gpu_mem"])]
+    for m in entry["mods"]:
+        args += ["--apply-mod", m]
+    for v in entry["volumes"]:
+        args += ["-v", v]
+    if setup:
+        args.append("--setup")
+    if config_path is not None:
+        args += ["--config", str(config_path)]
+    if entry["extra_args"]:
+        args += ["--", *entry["extra_args"]]
+    return args
+
+
+def health_url(host, port):
+    return f"http://{host}:{port}/health"
+
+
+def is_healthy(host, port, timeout=2):
+    try:
+        with urllib.request.urlopen(health_url(host, port), timeout=timeout) as resp:
+            return 200 <= resp.status < 300
+    except (urllib.error.URLError, OSError, ValueError):
+        return False
+
+
+def container_state(cname):
+    """Return the container's Docker state ('running', 'exited', ...) or None if absent."""
+    result = subprocess.run(
+        ["docker", "inspect", "-f", "{{.State.Status}}", cname],
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def wait_healthy(entry, host, timeout):
+    """Poll /health until ready. Returns None on success, else a failure reason.
+    Watches the container on its placement node so a crash fails fast. The
+    state probe runs only every STATE_CHECK_EVERY polls: for a remote entry
+    each probe is a fresh ssh round-trip, too costly to pay every 5s."""
+    cname = entry["container_name"]
+    poll_host = entry_host(entry, host)
+    deadline = time.monotonic() + timeout
+    url = health_url(poll_host, entry["port"])
+    print(f"    waiting for {url} (timeout {timeout}s)...", flush=True)
+    polls = 0
+    while time.monotonic() < deadline:
+        if is_healthy(poll_host, entry["port"]):
+            print("    ready.", flush=True)
+            return None
+        if polls % STATE_CHECK_EVERY == 0:
+            state = entry_container_state(entry)
+            if state not in ("running", "unreachable"):
+                return (
+                    f"container '{cname}' "
+                    + (f"is in state '{state}'" if state else "no longer exists")
+                    + " before becoming healthy"
+                )
+        polls += 1
+        time.sleep(HEALTH_POLL_INTERVAL)
+    hint = "" if not is_distributed(entry) else (
+        " (a worker container may have died; run --status to check every node)"
+    )
+    return f"did not become healthy within {timeout}s{hint}"
+
+
+# --------------------------------------------------------------------------- #
+# Sub-commands
+# --------------------------------------------------------------------------- #
+def cmd_dry_run(stack, host, setup, explicit_config):
+    print(f"=== Stack: {stack['name']} ({len(stack['entries'])} recipes) ===")
+    print(f"Health timeout per recipe: {stack['health_timeout']}s")
+    print_placement_summary(stack)
+    print("Load order (as listed == descending memory usage):")
+    print()
+    for i, entry in enumerate(stack["entries"], 1):
+        cmd = [
+            "./run-recipe.py",
+            *recipe_args(entry, setup=setup, config_path=explicit_config),
+        ]
+        print(f"{i}. {shlex.join(cmd)}")
+        print(f"   then wait for {health_url(entry_host(entry, host), entry['port'])}")
+        print()
+    return 0
+
+
+def cmd_up(stack, host, setup, explicit_config):
+    print(f"=== Bringing up stack: {stack['name']} ===", flush=True)
+    print_placement_summary(stack)
+    for i, entry in enumerate(stack["entries"], 1):
+        cname = entry["container_name"]
+        port = entry["port"]
+        poll_host = entry_host(entry, host)
+        print(
+            f"\n[{i}/{len(stack['entries'])}] {entry['recipe']} "
+            f"-> container '{cname}', port {port}",
+            flush=True,
+        )
+        # If something is already answering /health on this port: our own
+        # running container means this entry is already up (re-`up` is a
+        # no-op for it); anything else owns the port, and vLLM would fail to
+        # bind (host networking) while the health gate saw the impostor as
+        # "ready" — refuse up front.
+        if is_healthy(poll_host, port):
+            if entry_container_state(entry) == "running":
+                print(
+                    f"    '{cname}' is already up and healthy on port {port}; "
+                    "skipping.",
+                    flush=True,
+                )
+                continue
+            print(
+                f"\nError: port {port} is already serving /health but container "
+                f"'{cname}' is not running — another process owns that port. "
+                f"Recipes started before this one are left running.",
+                file=sys.stderr,
+            )
+            return 1
+        cmd = [
+            sys.executable,
+            str(RUN_RECIPE),
+            *recipe_args(entry, setup=setup, config_path=explicit_config),
+        ]
+        result = subprocess.run(cmd)
+        if result.returncode != 0:
+            print(
+                f"\nError: launching '{entry['recipe']}' failed "
+                f"(run-recipe.py exit {result.returncode}). "
+                f"Recipes started before this one are left running.",
+                file=sys.stderr,
+            )
+            return result.returncode
+        failure = wait_healthy(entry, host, stack["health_timeout"])
+        if failure:
+            print(
+                f"\nError: '{entry['recipe']}' (container '{cname}', port {port}) "
+                f"{failure}. Check logs: docker logs {cname}. "
+                f"Recipes started before this one are left running.",
+                file=sys.stderr,
+            )
+            return 1
+    print(f"\n=== Stack '{stack['name']}' is up. ===")
+    for entry in stack["entries"]:
+        print(f"  {entry['recipe']:40s} http://{entry_host(entry, host)}:{entry['port']}")
+    return 0
+
+
+def stop_command(entry, config_path=None):
+    """argv to tear down one entry per its placement. Forwards --config so
+    launch-cluster resolves LOCAL_IP from the same env that decided the
+    placement (needed to tell local from remote)."""
+    cmd = [str(LAUNCH_CLUSTER), *placement_flags(entry)]
+    cmd += ["--name", entry["container_name"], "stop"]
+    if config_path is not None:
+        cmd += ["--config", str(config_path)]
+    return cmd
+
+
+def remote_container_state(host, cname):
+    """Container state on a remote host: a docker state, 'unreachable', or None."""
+    result = subprocess.run(
+        [
+            "ssh", "-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=no",
+            "-o", "ConnectTimeout=5", host,
+            f"docker inspect -f '{{{{.State.Status}}}}' {shlex.quote(cname)}",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 255:
+        return "unreachable"
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def cmd_stop(stack, explicit_config):
+    print(f"=== Stopping stack: {stack['name']} ===")
+    print_placement_summary(stack)
+    rc = 0
+    # Stop in reverse (last-started first) as a courtesy; order is not critical.
+    for entry in reversed(stack["entries"]):
+        print(f"  stopping '{entry['container_name']}'...")
+        result = subprocess.run(stop_command(entry, explicit_config))
+        if result.returncode != 0:
+            rc = result.returncode
+    return rc
+
+
+def cmd_status(stack, host, env):
+    print(f"=== Stack: {stack['name']} ===")
+    print_placement_summary(stack)
+    header = f"{'RECIPE':40s} {'CONTAINER':20s} {'PORT':>6s} {'STATE':>10s} {'HEALTH':>8s}"
+    print(header)
+    print("-" * len(header))
+    for entry in stack["entries"]:
+        cname = entry["container_name"]
+        port = entry["port"]
+        raw_state = entry_container_state(entry)
+        state_str = raw_state or "absent"
+        health = "ok" if is_healthy(entry_host(entry, host), port) else "-"
+        print(
+            f"{entry['recipe']:40s} {cname:20s} {port:>6d} "
+            f"{state_str:>10s} {health:>8s}"
+        )
+        p = entry["placement"]
+        if p.kind == "distributed":
+            head, workers = split_head_workers(p.nodes, env)
+            # Reuse the state already fetched above — the distributed head is
+            # this machine, so entry_container_state already inspected it.
+            print(f"    [HEAD] {head or '?'}: {raw_state or 'absent'}")
+            for worker in workers:
+                worker_state = remote_container_state(worker, cname)
+                print(f"    [WORKER] {worker}: {worker_state or 'absent'}")
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# Entry point
+# --------------------------------------------------------------------------- #
+def main():
+    parser = argparse.ArgumentParser(
+        description="Serve multiple vLLM recipes at once, each with its own "
+        "placement: distributed across the cluster or pinned to one node.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "stack", nargs="?", help="Stack manifest: name under stacks/ or a path"
+    )
+    parser.add_argument(
+        "--list", "-l", action="store_true", help="List available stacks"
+    )
+    parser.add_argument(
+        "--setup",
+        action="store_true",
+        help="Pass --setup to each recipe (build image + download model if missing)",
+    )
+    parser.add_argument(
+        "--host",
+        default="localhost",
+        help="Host to poll for /health (default: localhost)",
+    )
+    parser.add_argument(
+        "--config",
+        dest="config_file",
+        metavar="FILE",
+        help="Path to .env configuration file (default: .env in script directory)",
+    )
+    action = parser.add_mutually_exclusive_group()
+    action.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the ordered run-recipe.py commands without executing",
+    )
+    action.add_argument("--stop", action="store_true", help="Stop the whole stack")
+    action.add_argument(
+        "--status", action="store_true", help="Show each container's state + health"
+    )
+    args = parser.parse_args()
+
+    if args.list:
+        if not STACKS_DIR.is_dir():
+            print("No stacks/ directory found.")
+            return 0
+        stacks = sorted(
+            p.stem for p in STACKS_DIR.glob("*.y*ml") if p.suffix in (".yaml", ".yml")
+        )
+        print("Available stacks:")
+        for s in stacks:
+            print(f"  {s}")
+        return 0
+
+    if not args.stack:
+        parser.error("a stack name/path is required (or use --list)")
+
+    explicit_config = (
+        Path(args.config_file).resolve() if args.config_file else None
+    )
+    if explicit_config is not None and not explicit_config.is_file():
+        # A typo'd --config silently loading as an empty env would flip a
+        # cluster-sized stack onto one host; only the *default* .env may be
+        # absent without complaint.
+        print(
+            f"Error: --config file not found: {args.config_file}",
+            file=sys.stderr,
+        )
+        return 1
+    config_path = explicit_config or (SCRIPT_DIR / ".env")
+    env = run_recipe.load_env_file(config_path)
+    try:
+        master_base = int(env.get("MASTER_PORT") or DEFAULT_MASTER_PORT)
+    except (TypeError, ValueError):
+        print(
+            f"Error: MASTER_PORT in {config_path} must be an integer, "
+            f"got {env.get('MASTER_PORT')!r}.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        stack = load_stack(args.stack, master_base, env, config_path)
+    except (FileNotFoundError, ValueError, yaml.YAMLError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    try:
+        if not (args.stop or args.status):
+            # Launch paths only: --stop/--status must inspect/tear down even
+            # a stack whose recipes' mode flags contradict its placements.
+            validate_modes(stack)
+    except ModeConflictError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return EXIT_MODE_CONFLICT
+
+    if args.stop:
+        return cmd_stop(stack, explicit_config)
+    if args.status:
+        return cmd_status(stack, args.host, env)
+    if args.dry_run:
+        return cmd_dry_run(stack, args.host, args.setup, explicit_config)
+    return cmd_up(stack, args.host, args.setup, explicit_config)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/run-stack.sh
+++ b/run-stack.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# run-stack.sh - Wrapper for run-stack.py
+#
+# Serve multiple vLLM recipes at once, each with its own placement. Ensures
+# Python dependencies are available and runs the stack runner. See
+# stacks/README.md for the manifest format.
+#
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "$SCRIPT_DIR/ensure-python.sh"
+
+exec $PYTHON "$SCRIPT_DIR/run-stack.py" "$@"

--- a/stacks/README.md
+++ b/stacks/README.md
@@ -1,0 +1,229 @@
+# Stacks — serving multiple recipes at once
+
+A **stack** runs several vLLM recipes at once, each in its own Docker container
+on its own port, sharing the same on-disk model cache. Each recipe picks its
+own **placement** independently — distributed across the cluster, pinned alone
+to one node (local or remote), or left to the default. The simplest stack
+co-locates two models on one machine (e.g. a large chat model on `:8000` and a
+small tool/coder model on `:8001`); the same manifest format also spreads one
+model across the cluster while pinning another to a specific node.
+
+Stacks are a thin layer over the normal recipe flow: `run-stack.py` calls
+`run-recipe.py` once per recipe, so everything recipes already do — mods, model
+download, container image selection, command templating — works unchanged.
+`run-stack.py` passes each distributed recipe its own `--master-port` so
+co-located distributed recipes don't collide. See **Placement** below.
+
+## Quick start
+
+```bash
+./run-stack.sh --list                                    # list stacks/*.yaml
+./run-stack.sh stacks/example-dual-stack.yaml --dry-run  # show the ordered launch plan
+./run-stack.sh stacks/example-dual-stack.yaml --setup    # build/download as needed, then bring up
+./run-stack.sh stacks/example-dual-stack.yaml --status   # per-container state + /health
+./run-stack.sh stacks/example-dual-stack.yaml --stop     # tear the whole stack down
+```
+
+A stack can be named by path, as above, or by bare name — `run-stack.sh` looks
+for a literal path first, then `stacks/<name>`, `stacks/<name>.yaml`, and
+`stacks/<name>.yml`. So `./run-stack.sh example-dual-stack --status` is
+equivalent to the third line above.
+
+## Why order matters (and why it's sequential)
+
+Recipes are launched **in the order listed**, and that order **must be
+descending memory usage**. vLLM profiles free memory at startup, so the largest
+model must claim its slice of the unified memory pool first — and fail fast if it
+won't fit. Each recipe is started only after the previous one's `/health`
+endpoint reports ready (`health_timeout` seconds, default 1200). This also
+serializes first-time kernel compilation so co-located instances don't race on
+the shared compile caches (`~/.cache/vllm`, `flashinfer`, `triton`, `tilelang`).
+
+## Manifest format
+
+```yaml
+stack_version: "1"
+name: my-stack                 # optional; defaults to the file name
+description: ...               # optional
+health_timeout: 1200          # optional, seconds per recipe
+
+recipes:                      # required; listed in DESCENDING memory order
+  - recipe: <name-or-path>    # required; resolved like run-recipe.py (recipes/<name>.yaml)
+    container_name: <name>    # optional; Docker --name, must be unique across the stack
+                              #   (defaults to a sanitized recipe name)
+    port: <int>               # optional; defaults to the recipe's defaults.port
+    placement: all | <IP>     # optional; defaults to 'all' -- see "Placement" below
+    gpu_mem: <float>          # optional; fraction override -> run-recipe.py --gpu-mem
+    master_port: <int>        # optional; distributed recipes only, see "Placement" below
+    mods: [<path>, ...]       # optional; extra --apply-mod paths (repo-relative)
+    volumes: [<mapping>, ...] # optional; Docker -v host:container[:options] mounts
+    extra_args: [<arg>, ...]  # optional; appended after `--` to run-recipe.py (vLLM args)
+```
+
+The **served model name** (`--served-model-name`) stays recipe-owned —
+`run-stack.py` doesn't invent it. The **port** defaults to the recipe's
+`defaults.port` and can be overridden per entry; `run-stack.py` never picks one
+itself. `container_name`s must be unique across the whole stack (so
+`--stop`/`--status` and `docker logs <name>` are unambiguous); `port`s must be
+unique **per node** (two entries pinned to different nodes may reuse a port),
+or the run aborts with a clear error before anything launches.
+
+### Extra mounts (`volumes`)
+
+`volumes` forwards Docker's `-v host:container[:options]` to `run-recipe.py`
+per entry — for local weights, datasets, or an output directory the HF cache
+mounts don't already cover:
+
+```yaml
+  - recipe: qwen3.6-35b-a3b-nvfp4
+    volumes:
+      - /srv/models:/models:ro
+      - datasets/eval:/eval      # repo-relative, resolved to an absolute path
+```
+
+A relative host path is resolved against the repo root, like `mods`; `~` is
+expanded. A bare token with no `/` (e.g. `hfcache:/root/.cache/huggingface`) is
+left alone, since Docker reads that as a **named volume**. The container path
+must be absolute, and mappings containing whitespace or shell metacharacters are
+refused — `launch-cluster.sh` expands the mount unquoted into the `docker run`
+line, so they would word-split or execute rather than mount. All of these are
+checked before anything launches.
+
+> **Host paths are resolved on the machine running `run-stack`, but mounted on
+> the placement node.** An entry with `placement: all` runs a container on every
+> node in the cluster and applies the same `-v` to each, so the host path must
+> exist on **all** of them. A `placement: <IP>` entry has the same trap in
+> smaller form: a relative or `~` path is expanded here and then shipped to that
+> node over ssh. Docker does not fail on a missing host path — it silently
+> creates an empty root-owned directory and mounts that. **Prefer absolute host
+> paths for any entry that is not local**, and confirm the path exists there.
+> Mounts are per entry: they never leak to other recipes in the stack.
+
+### Memory budgeting: fractions vs absolute GiB
+
+`gpu_mem` sets vLLM's `--gpu-memory-utilization` as a **fraction of total**
+memory; the fractions across co-located recipes must sum to **< 1** with headroom
+for CUDA context and non-torch allocations.
+
+Absolute GiB budgets compose more predictably when stacking. The
+[`mods/gpu-mem-util-gb`](../mods/gpu-mem-util-gb) mod patches vLLM to accept
+`--gpu-memory-utilization-gb`; add it per entry and pass the flag via
+`extra_args` (see the commented block in `example-dual-stack.yaml`).
+
+## Placement
+
+Each recipe entry picks its own `placement`, independent of every other entry
+in the stack — a single manifest can distribute one model across the cluster
+while pinning another alone to a specific node (see
+`example-cluster-stack.yaml`).
+
+- **`placement: all`** (the default when the key is omitted) distributes the
+  recipe across every node in `.env`'s `CLUSTER_NODES` (or the `--config` file
+  passed to `run-stack.py`). **If `CLUSTER_NODES` has fewer than two nodes
+  (unset, empty, or a single node), it runs solo on this host** — the normal
+  case on a single Spark, so this is not an error and not a warning. A recipe
+  marked `cluster_only:` in that position *is* refused outright, before
+  anything launches. For an unflagged recipe genuinely sized to spread across
+  a cluster, though, nothing stops the attempt to fit it on one host, and it
+  can OOM. The placement summary printed by every sub-command names the target
+  of each entry (`-> distributed across N nodes` / `-> this host` / `-> node
+  <IP>`); check it, or `--dry-run` first, before trusting that a stack is
+  actually running distributed.
+
+- **`placement: <IP>`** pins the recipe alone to that one node — not
+  distributed — whether the IP is this machine (`LOCAL_IP` in `.env`/`--config`)
+  or a remote node. The IP **must** be either `LOCAL_IP` or one of
+  `CLUSTER_NODES`; an unrecognized IP is rejected at load time, before
+  anything launches, naming the IP and the nodes it was checked against.
+
+- **Pinning to the invoking host requires `LOCAL_IP` to be set.** Without
+  `LOCAL_IP` in `.env`/`--config`, `run-stack.py`, `run-recipe.py`, and
+  `launch-cluster.sh` have no way to know that a listed IP refers to this
+  machine, and may disagree on whether it's local — treating a pin meant for
+  "here" as remote and ssh'ing back into this machine instead of running
+  locally.
+
+- **Ports are unique per node, not per stack.** Two entries may reuse the same
+  `port` as long as they resolve to different nodes (e.g. one distributed
+  across the cluster, one pinned elsewhere) — `run-stack.py` tracks
+  `(node, port)` pairs, not just `port`.
+
+- **`master_port` applies only to distributed recipes** (`placement: all`
+  resolving to 2+ nodes); a `single`-placement entry (solo or pinned) never
+  uses cluster coordination and ignores it. If you don't set it, `run-stack.py`
+  auto-assigns one per distributed entry as base + index in manifest order,
+  where the base is `.env`'s `MASTER_PORT` if set, else 29501 — so with the
+  default base entries get 29501, 29502, …, and co-located distributed
+  recipes never collide with each other by default. Override it explicitly
+  when the auto-assigned value collides with something else on the network,
+  or you need a stable port across manifest edits.
+
+- **`--status` and `--stop` target each entry's own resolved node** — ssh'ing
+  to a remote pinned node or to every worker of a distributed entry as needed
+  — not a single stack-wide mode. The health gate that watches for a startup
+  failure while bringing an entry up also targets that entry's node (its head
+  node if distributed, its pinned node if pinned).
+
+- **`--setup` fans out per entry**, and per node for a distributed entry. Each
+  recipe with `--setup` re-runs image build and model distribution to every
+  node it resolves to, not just once for the stack. This is correct (each
+  entry may need different images/mods, and a distributed entry needs the
+  image/model on every node it spans) but slow on a cold cluster — expect the
+  first `--setup` run to take substantially longer than subsequent ones once
+  images and models are cached everywhere.
+
+- **Run `run-stack.sh` on the node you expect distributed entries to head
+  from.** A distributed entry's head is not `nodes[0]` — it is whichever
+  *listed* node is the invoking machine (`launch-cluster.sh` derives it from
+  the local IP). Invoking from a different listed node silently makes *that*
+  node the head for that entry, inverting the intended roles; invoking from a
+  machine that isn't in the node list at all makes `launch-cluster.sh` refuse
+  to launch before anything starts. `--host` (used to poll `/health` for
+  non-pinned entries) defaults to `localhost`, which matches the head only
+  when you run the stack from it.
+
+- **`gpu_mem` budgeting is per node, not per stack or per cluster.** A node
+  that hosts a shard of a distributed recipe *and* a recipe pinned to it must
+  fit both: under tensor-parallel sharding every node in a distributed
+  recipe's cluster holds a shard of that recipe, so a pinned entry sharing one
+  of those nodes needs its `gpu_mem` sized against what the shard already
+  uses there, not against the distributed recipe's total footprint across the
+  whole cluster. A recipe's *default* `gpu_memory_utilization` is tuned for
+  running that model *alone*, so every co-located entry on a node still needs
+  an explicit `gpu_mem` (or an absolute-GiB budget via
+  `mods/gpu-mem-util-gb`) chosen so the totals on that node leave headroom.
+  See `example-cluster-stack.yaml` for a worked example (two `placement: all`
+  entries plus one pinned to a node also carrying a distributed shard).
+
+- **A stray top-level `solo_only:` key is ignored, with a warning.** Older
+  manifests set a stack-wide `solo_only:` to force every recipe solo; that key
+  has been replaced by per-recipe `placement:` and is no longer read for
+  anything but the warning — remove it and set `placement:` per entry instead.
+
+- **A recipe's own `cluster_only`/`solo_only` (in the *recipe* YAML, not the
+  stack) still applies.** These are separate, per-recipe restrictions
+  unrelated to stack placement — some models genuinely cannot run distributed
+  (or cannot run solo) regardless of what a stack asks for. A recipe whose
+  resolved placement contradicts its own restriction is rejected at load time,
+  naming the conflict and how to fix it (use `placement: all` with a
+  configured cluster, or pin with `placement: <node-IP>`).
+
+## Limitations when co-locating
+
+- **Total memory** — the sum of all recipes co-located on a given node
+  (weights + KV cache + activations) must fit that node, with headroom. This
+  is the main constraint on a GB10's 128 GB unified pool.
+- **Cluster coordination port** — each distributed recipe binds a master port on
+  its head node (`--master-port`, default 29501), used by both the no-Ray
+  PyTorch backend and the Ray head. Co-located distributed recipes therefore need
+  distinct ports; stacks assigns base + index automatically (base = `.env`'s
+  `MASTER_PORT`, else 29501 — so `29501`, `29502`, … by default), and
+  `master_port:` overrides an entry if something else owns that range.
+- **Shared `/dev/shm` (`--ipc=host`)** — vLLM's engine↔API-server IPC uses shared
+  memory; heavy co-location may need `--non-privileged` (per-container
+  `--shm-size`), which the underlying recipe/launcher already supports.
+- **One GPU** — compute is time-sliced across containers (no MIG on GB10);
+  functionally fine, but throughput contends under simultaneous load.
+- **`cluster_only`/`solo_only` recipes** (the recipe's own field) still can't
+  be placed in a way that contradicts them — see the last two bullets under
+  **Placement** above.

--- a/stacks/example-cluster-stack.yaml
+++ b/stacks/example-cluster-stack.yaml
@@ -1,0 +1,65 @@
+stack_version: "1"
+name: example-cluster-stack
+# Three models, three different placements, one manifest -- which is the whole
+# point of a per-recipe 'placement:' key:
+#
+#   qwen3.6-35b-a3b-fp8    sharded across every node in CLUSTER_NODES
+#   nemotron-3-nano-nvfp4  pinned alone to 10.0.1.1
+#   gemma4-26b-a4b-nvfp4   pinned alone to 10.0.1.2
+#
+# The two pinned recipes are marked solo_only, so they CANNOT be sharded --
+# 'placement: all' would be refused outright (exit 3). Pinning is what lets
+# them run on a cluster at all, and putting one on each node keeps them from
+# competing for the same node's memory.
+#
+# Sized for the two-node cluster in .env's CLUSTER_NODES. Illustrative only:
+# tune gpu_mem to your own models and hardware.
+health_timeout: 1800
+
+recipes:
+  # Largest first: vLLM profiles free memory at startup, so the biggest model
+  # must claim its slice against a clean pool.
+  - recipe: qwen3.6-35b-a3b-fp8
+    container_name: qwen_fp8
+    port: 8000                     # served on the head node
+    placement: all                 # shard across every node in CLUSTER_NODES
+    gpu_mem: 0.40                  # recipe default is 0.8; halved so each node's shard leaves room for the model pinned beside it
+    # master_port auto-assigns base + 0 (base = .env MASTER_PORT, else 29501).
+    # Only distributed entries use one -- it is where the shards coordinate --
+    # and each gets a distinct port so co-located distributed recipes can't collide.
+    # extra_args go to vLLM (after run-recipe's `--`). --load-format instanttensor
+    # cuts the peak memory spike during weight load — the transient that most
+    # often decides whether co-located models fit on each node.
+    extra_args: ["--load-format", "instanttensor"]
+
+  # ---- The other form: pin a model to ONE node instead of sharding it ----
+  # 'placement: <IP>' runs the recipe alone on that node. The IP must be either
+  # this machine (LOCAL_IP) or a node listed in CLUSTER_NODES; anything else is
+  # rejected at load time, before a single container starts.
+  #
+  # You do not declare which node is local. Whichever IP matches .env's
+  # LOCAL_IP runs here; the other is driven over ssh. So the same manifest
+  # works unchanged from either node -- only which of the two entries is the
+  # remote one changes. The comments below assume you launch from 10.0.1.1.
+  - recipe: nemotron-3-nano-nvfp4
+    container_name: nano-nvfp4
+    port: 8001                     # served on http://10.0.1.1:8001
+    placement: 10.0.1.1            # matches LOCAL_IP here, so it runs locally
+    gpu_mem: 0.38                  # recipe default is 0.7 — must be lowered to fit beside the qwen shard
+    extra_args: ["--load-format", "instanttensor"]
+
+  - recipe: gemma4-26b-a4b-nvfp4
+    container_name: gemma4-nvfp4
+    port: 8001                     # the same port as above is fine: different node
+    placement: 10.0.1.2            # the other node: run-stack drives it over ssh
+    gpu_mem: 0.38                  # recipe default is 0.7
+    extra_args: ["--load-format", "instanttensor"]
+
+# gpu_mem is a PER-NODE budget, not a cluster-wide one. Under tensor-parallel
+# sharding every node holds a shard of the distributed model, and that shard
+# shares the node with whatever is pinned there:
+#   10.0.1.1: 0.40 (qwen shard) + 0.38 (nemotron, pinned) = 0.78
+#   10.0.1.2: 0.40 (qwen shard) + 0.38 (gemma4, pinned)   = 0.78
+# Both nodes stay under 1.0, leaving headroom for CUDA context and non-torch
+# allocations. Run --dry-run first: it prints the resolved placement for every
+# entry, so you can confirm what lands where before anything allocates memory.

--- a/stacks/example-dual-stack.yaml
+++ b/stacks/example-dual-stack.yaml
@@ -1,0 +1,73 @@
+stack_version: "1"
+name: example-dual-stack
+description: >
+  Two NVFP4 models co-located on one DGX Spark GB10 — a 35B MoE alongside a
+  smaller single-node model. Illustrative only: tune the memory budgets and
+  load order to your actual models and hardware.
+
+# Seconds to wait for each recipe's /health before giving up (optional).
+health_timeout: 1200
+
+# Recipes are served in the order listed, and that order MUST be
+# DESCENDING memory usage: the largest model claims its slice of the unified
+# memory pool first (and fails fast if it won't fit), then the next is started
+# only after the previous one reports healthy.
+#
+# SINGLE-HOST example: run it on a machine with no cluster configured, and both
+# models load here side by side. Neither entry sets 'placement:', so both take
+# the default, 'all' -- every node available to this host. With no CLUSTER_NODES
+# that is just this one machine, exactly as if each entry had been pinned to
+# LOCAL_IP.
+#
+# On a host that DOES have a cluster configured, 'all' means what it says and
+# this stack is refused (exit 3): nemotron-3-nano-nvfp4 is solo_only and cannot
+# be sharded. To co-locate both models on one node of a cluster, pin every entry
+# with 'placement: <that node's IP>'. For a stack that genuinely spans a
+# cluster, see example-cluster-stack.yaml.
+recipes:
+  # ---- Largest first ----
+  - recipe: qwen3.6-35b-a3b-nvfp4
+    container_name: qwen_nvfp4     # Docker --name; must be unique across the stack
+    port: 8000                     # served on http://host:8000
+    gpu_mem: 0.45                  # fraction of unified memory (run-recipe.py --gpu-mem); recipe default is 0.4
+    # extra_args are passed to vLLM (after run-recipe's `--`). --load-format
+    # instanttensor slashes the PEAK memory spike while weights load, which is
+    # what usually decides whether a second model still fits alongside the first.
+    extra_args: ["--load-format", "instanttensor"]
+
+  # ---- Smaller second ----
+  - recipe: nemotron-3-nano-nvfp4
+    container_name: nemotron_nano
+    port: 8001                     # served on http://host:8001
+    gpu_mem: 0.40                  # recipe default is 0.7 — must be lowered to fit beside the first model
+    extra_args: ["--load-format", "instanttensor"]
+    # Extra bind mounts for this entry only (Docker -v host:container[:options]).
+    # A relative host path is resolved against the repo root; a bare token with
+    # no '/' stays a named Docker volume. NOTE: paths are resolved on THIS
+    # machine but mounted on the placement node, and an entry with placement
+    # 'all' mounts on EVERY node it runs on -- so prefer absolute paths and make
+    # sure they exist there, or docker silently mounts an empty root-owned dir.
+    # volumes: ["/srv/models:/models:ro"]
+
+# The two gpu_mem fractions above sum to 0.85, leaving headroom for CUDA
+# context and non-torch allocations on the shared 128 GB pool.
+#
+# ----------------------------------------------------------------------------
+# PREFERRED for stacking: absolute GiB budgets compose more predictably than
+# fractions-of-total. Add the gpu-mem-util-gb mod (which patches vLLM to accept
+# --gpu-memory-utilization-gb) and pass the flag via extra_args. Every vLLM flag
+# for one entry goes in the SAME extra_args list, so combine it with the
+# load-format override above, e.g.:
+#
+#   - recipe: qwen3.6-35b-a3b-nvfp4
+#     container_name: qwen_nvfp4
+#     port: 8000
+#     mods: [mods/gpu-mem-util-gb]
+#     extra_args: ["--load-format", "instanttensor", "--gpu-memory-utilization-gb", "60"]
+#
+#   - recipe: nemotron-3-nano-nvfp4
+#     container_name: nemotron_nano
+#     port: 8001
+#     mods: [mods/gpu-mem-util-gb]
+#     extra_args: ["--load-format", "instanttensor", "--gpu-memory-utilization-gb", "40"]
+# ----------------------------------------------------------------------------

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# lib.sh - Shared harness for the test suites (sourced, not executed).
+#
+# Callers set VERBOSE (to "-v" for verbose output) before sourcing.
+#
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Test counters
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_SKIPPED=0
+
+log_test() {
+    echo -e "${YELLOW}[TEST]${NC} $1"
+}
+
+log_pass() {
+    echo -e "${GREEN}[PASS]${NC} $1"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+}
+
+log_fail() {
+    echo -e "${RED}[FAIL]${NC} $1"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+}
+
+log_skip() {
+    echo -e "${YELLOW}[SKIP]${NC} $1"
+    TESTS_SKIPPED=$((TESTS_SKIPPED + 1))
+}
+
+log_verbose() {
+    if [[ "$VERBOSE" == "-v" ]]; then
+        echo "       $1"
+    fi
+    return 0
+}
+
+# assert_contains <description> <haystack> <needle>
+assert_contains() {
+    if [[ "$2" == *"$3"* ]]; then
+        log_pass "$1"
+    else
+        log_fail "$1"
+        log_verbose "expected to find: $3"
+        log_verbose "in output:"
+        log_verbose "$2"
+    fi
+}

--- a/tests/test_recipes.sh
+++ b/tests/test_recipes.sh
@@ -20,42 +20,8 @@ VERBOSE="${1:-}"
 # Load expected commands for README verification
 source "$SCRIPT_DIR/expected_commands.sh"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
-
-# Test counters
-TESTS_PASSED=0
-TESTS_FAILED=0
-TESTS_SKIPPED=0
-
-# Helper functions
-log_test() {
-    echo -e "${YELLOW}[TEST]${NC} $1"
-}
-
-log_pass() {
-    echo -e "${GREEN}[PASS]${NC} $1"
-    TESTS_PASSED=$((TESTS_PASSED + 1))
-}
-
-log_fail() {
-    echo -e "${RED}[FAIL]${NC} $1"
-    TESTS_FAILED=$((TESTS_FAILED + 1))
-}
-
-log_skip() {
-    echo -e "${YELLOW}[SKIP]${NC} $1"
-    TESTS_SKIPPED=$((TESTS_SKIPPED + 1))
-}
-
-log_verbose() {
-    if [[ "$VERBOSE" == "-v" ]]; then
-        echo "       $1"
-    fi
-}
+# Shared harness: colors, counters, log_*/assert_contains helpers
+source "$SCRIPT_DIR/lib.sh"
 
 get_recipe_flag() {
     local flag_name="$1"
@@ -1069,6 +1035,64 @@ test_launch_cmd_earlyoom_rejects_keep_entrypoint() {
     fi
 }
 
+# Test: --placement-node forwards to launch-cluster.sh as a solo run (no -n)
+test_launch_cmd_placement_node() {
+    log_test "--placement-node forwards to launch-cluster as solo with no -n"
+
+    OUT="$("$PROJECT_DIR/run-recipe.py" qwen3.6-35b-a3b-nvfp4 --placement-node 10.0.0.2 --name a -d --port 8000 --dry-run 2>&1)"; RC=$?
+    LC_LINE="$(echo "$OUT" | grep -E 'launch-cluster\.sh')"
+    if [[ $RC -eq 0 && "$LC_LINE" == *"--placement-node 10.0.0.2"* && "$LC_LINE" != *"-n "* \
+          && ( "$OUT" == *"--tensor-parallel-size 1"* || "$OUT" == *"-tp 1"* ) ]]; then
+        log_pass "placement-node forwarded, solo (TP=1), no -n"
+    else
+        log_fail "placement-node forwarded, solo (TP=1), no -n (rc=$RC)"
+        log_verbose "$OUT"
+    fi
+}
+
+# Test: A --placement-node targeting THIS machine must not trigger a
+# self-copy in --setup, even when .env has no LOCAL_IP (the fresh-node case
+# --placement-node is meant to serve). A genuinely remote IP still copies.
+test_placement_node_no_self_copy_without_local_ip() {
+    log_test "--placement-node to this host + --setup skips self-copy when .env lacks LOCAL_IP"
+
+    local this_ip
+    this_ip="$(python3 -c 'import socket; print(socket.gethostbyname(socket.gethostname()))')"
+
+    local no_local_ip_env
+    no_local_ip_env="$(mktemp)"
+    echo "CLUSTER_NODES=" > "$no_local_ip_env"
+
+    OUT="$("$PROJECT_DIR/run-recipe.py" qwen3.6-35b-a3b-nvfp4 --placement-node "$this_ip" --name x -d --port 8000 --setup --config "$no_local_ip_env" --dry-run 2>&1)"; RC=$?
+    rm -f "$no_local_ip_env"
+
+    if [[ $RC -eq 0 && "$OUT" != *"Would copy to: $this_ip"* && "$OUT" != *"copy to workers: $this_ip"* ]]; then
+        log_pass "local placement (no LOCAL_IP in .env) does not self-copy"
+    else
+        log_fail "local placement (no LOCAL_IP in .env) wrongly shows a copy target (rc=$RC)"
+        log_verbose "$OUT"
+    fi
+
+    log_test "--placement-node to a genuinely remote host + --setup still copies"
+
+    local remote_env
+    remote_env="$(mktemp)"
+    echo "CLUSTER_NODES=" > "$remote_env"
+
+    OUT="$("$PROJECT_DIR/run-recipe.py" qwen3.6-35b-a3b-nvfp4 --placement-node 10.99.99.99 --name x -d --port 8000 --setup --config "$remote_env" --dry-run 2>&1)"; RC=$?
+    rm -f "$remote_env"
+
+    # Accept either wording: the download phase prints "Would copy to:" while the
+    # build phase prints "...copy to workers:" — which one fires depends on
+    # whether the model/image already exist in this box's caches (unrelated state).
+    if [[ $RC -eq 0 && ( "$OUT" == *"Would copy to: 10.99.99.99"* || "$OUT" == *"copy to workers: 10.99.99.99"* ) ]]; then
+        log_pass "remote placement still yields a copy target"
+    else
+        log_fail "remote placement did not yield a copy target (rc=$RC)"
+        log_verbose "$OUT"
+    fi
+}
+
 # ==============================================================================
 # README Documentation Verification Tests
 # ==============================================================================
@@ -1575,6 +1599,8 @@ main() {
     test_launch_cmd_keep_entrypoint_passthrough
     test_launch_cmd_earlyoom_passthrough
     test_launch_cmd_earlyoom_rejects_keep_entrypoint
+    test_launch_cmd_placement_node
+    test_placement_node_no_self_copy_without_local_ip
     echo ""
     
     # README documentation verification tests

--- a/tests/test_stack.sh
+++ b/tests/test_stack.sh
@@ -1,0 +1,916 @@
+#!/bin/bash
+#
+# test_stack.sh - Tests for run-stack.py (multi-recipe co-location).
+#
+# Uses --dry-run and validation paths only; never launches containers.
+# Suitable for CI.
+#
+# Usage:
+#   ./tests/test_stack.sh        # run all tests
+#   ./tests/test_stack.sh -v     # verbose
+#
+
+set +e
+
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+RUN_STACK="$PROJECT_DIR/run-stack.py"
+VERBOSE="${1:-}"
+
+# Shared harness: colors, counters, log_*/assert_contains helpers
+source "$SCRIPT_DIR/lib.sh"
+
+TMPDIR_STACK="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_STACK"' EXIT
+
+# An empty .env: forces solo-local resolution regardless of the developer's
+# own .env (this repo's real .env sets CLUSTER_NODES). Created once up front
+# so every solo-regression test below can force it explicitly.
+: > "$TMPDIR_STACK/empty.env"
+
+echo "========================================"
+echo "run-stack.py tests"
+echo "========================================"
+
+# ---- 1. --list surfaces the example stack ----
+log_test "--list includes example-dual-stack"
+OUT="$("$RUN_STACK" --list 2>&1)"
+assert_contains "example-dual-stack listed" "$OUT" "example-dual-stack"
+
+# ---- 2. example-dual-stack dry-run: order, names, ports ----
+log_test "example-dual-stack --dry-run launch plan"
+OUT="$("$RUN_STACK" example-dual-stack --dry-run \
+        --config "$TMPDIR_STACK/empty.env" 2>&1)"
+log_verbose "$OUT"
+## --config is forwarded to each run-recipe.py invocation (test 23 covers this
+## explicitly), so it lands between --gpu-mem and the -- extra_args separator;
+## check the recipe-args prefix and the extra_args suffix as two substrings
+## (same style as test 6) instead of one contiguous string.
+assert_contains "entry 1 is qwen (largest first)" "$OUT" \
+    "1. ./run-recipe.py qwen3.6-35b-a3b-nvfp4 --solo --name qwen_nvfp4 -d --port 8000 --gpu-mem 0.45"
+assert_contains "entry 2 is nemotron" "$OUT" \
+    "2. ./run-recipe.py nemotron-3-nano-nvfp4 --solo --name nemotron_nano -d --port 8001 --gpu-mem 0.4 --config"
+assert_contains "extra_args after --" "$OUT" "-- --load-format instanttensor"
+assert_contains "health gate on port 8000" "$OUT" "http://localhost:8000/health"
+assert_contains "health gate on port 8001" "$OUT" "http://localhost:8001/health"
+# Order check: qwen must appear before nemotron in the output.
+if [[ "$OUT" == *"qwen_nvfp4"*"nemotron_nano"* ]]; then
+    log_pass "load order preserved (qwen before nemotron)"
+else
+    log_fail "load order preserved (qwen before nemotron)"
+fi
+
+# ---- 3. duplicate port aborts before launching ----
+log_test "duplicate port is rejected"
+cat > "$TMPDIR_STACK/dup-port.yaml" <<'EOF'
+name: dup-port
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: a, port: 8000}
+  - {recipe: nemotron-3-nano-nvfp4, container_name: b, port: 8000}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/dup-port.yaml" --dry-run 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"port 8000"* && "$OUT" == *"already used"* ]]; then
+    log_pass "duplicate port errors with nonzero exit"
+else
+    log_fail "duplicate port errors with nonzero exit (rc=$RC)"
+    log_verbose "$OUT"
+fi
+
+# ---- 4. duplicate container_name aborts ----
+log_test "duplicate container_name is rejected"
+cat > "$TMPDIR_STACK/dup-name.yaml" <<'EOF'
+name: dup-name
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: a, port: 8000}
+  - {recipe: nemotron-3-nano-nvfp4, container_name: a, port: 8001}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/dup-name.yaml" --dry-run 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"duplicate container_name"* ]]; then
+    log_pass "duplicate container_name errors with nonzero exit"
+else
+    log_fail "duplicate container_name errors with nonzero exit (rc=$RC)"
+    log_verbose "$OUT"
+fi
+
+# ---- 5. port defaults from the recipe when omitted ----
+log_test "omitted port inherits recipe defaults.port"
+cat > "$TMPDIR_STACK/default-port.yaml" <<'EOF'
+name: default-port
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: only}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/default-port.yaml" --dry-run \
+        --config "$TMPDIR_STACK/empty.env" 2>&1)"
+# qwen3.6-35b-a3b-nvfp4 recipe declares defaults.port: 8000
+assert_contains "default port 8000 applied" "$OUT" "--port 8000"
+
+# ---- 6. mods resolve to absolute paths; extra_args land after `--` ----
+log_test "mods + extra_args rendering"
+cat > "$TMPDIR_STACK/mods.yaml" <<'EOF'
+name: mods
+recipes:
+  - recipe: qwen3.6-35b-a3b-nvfp4
+    container_name: q
+    port: 8000
+    mods: [mods/gpu-mem-util-gb]
+    extra_args: ["--gpu-memory-utilization-gb", 60]
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/mods.yaml" --dry-run \
+        --config "$TMPDIR_STACK/empty.env" 2>&1)"
+log_verbose "$OUT"
+assert_contains "mod resolved to absolute path" "$OUT" \
+    "--apply-mod $PROJECT_DIR/mods/gpu-mem-util-gb"
+assert_contains "extra_args after --" "$OUT" \
+    "-- --gpu-memory-utilization-gb 60"
+
+# ---- 7. nonexistent recipe is rejected ----
+log_test "nonexistent recipe is rejected"
+cat > "$TMPDIR_STACK/bad-recipe.yaml" <<'EOF'
+name: bad-recipe
+recipes:
+  - {recipe: this-recipe-does-not-exist, container_name: a, port: 8000}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/bad-recipe.yaml" --dry-run 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"not found"* ]]; then
+    log_pass "nonexistent recipe errors with nonzero exit"
+else
+    log_fail "nonexistent recipe errors with nonzero exit (rc=$RC)"
+    log_verbose "$OUT"
+fi
+
+# ---- 8. malformed YAML gives a clean error, not a traceback ----
+log_test "malformed YAML is rejected cleanly"
+printf 'recipes: [\n  {broken' > "$TMPDIR_STACK/malformed.yaml"
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/malformed.yaml" --dry-run 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"Error:"* && "$OUT" != *"Traceback"* ]]; then
+    log_pass "malformed YAML errors without a traceback"
+else
+    log_fail "malformed YAML errors without a traceback (rc=$RC)"
+    log_verbose "$OUT"
+fi
+
+# ---- 8b. stack YAML whose top level is not a mapping is rejected cleanly ----
+log_test "non-mapping stack YAML is rejected cleanly"
+printf -- '- just\n- a list\n' > "$TMPDIR_STACK/list-stack.yaml"
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/list-stack.yaml" --dry-run 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"Error:"* && "$OUT" == *"mapping"* && "$OUT" != *"Traceback"* ]]; then
+    log_pass "list-shaped stack YAML errors without a traceback"
+else
+    log_fail "list-shaped stack YAML errors without a traceback (rc=$RC)"
+    log_verbose "$OUT"
+fi
+
+# ---- 9. invalid container_name is rejected ----
+log_test "invalid container_name is rejected"
+cat > "$TMPDIR_STACK/bad-name.yaml" <<'EOF'
+name: bad-name
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: "has space", port: 8000}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/bad-name.yaml" --dry-run 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"not a valid Docker container name"* ]]; then
+    log_pass "invalid container_name errors with nonzero exit"
+else
+    log_fail "invalid container_name errors with nonzero exit (rc=$RC)"
+    log_verbose "$OUT"
+fi
+
+# ---- 10. unsupported stack_version is rejected ----
+log_test "unsupported stack_version is rejected"
+cat > "$TMPDIR_STACK/future.yaml" <<'EOF'
+stack_version: "99"
+name: future
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: a, port: 8000}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/future.yaml" --dry-run 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"unsupported stack_version"* ]]; then
+    log_pass "unsupported stack_version errors with nonzero exit"
+else
+    log_fail "unsupported stack_version errors with nonzero exit (rc=$RC)"
+    log_verbose "$OUT"
+fi
+
+# ---- 11. non-integer health_timeout names the field ----
+log_test "non-integer health_timeout is rejected"
+cat > "$TMPDIR_STACK/bad-timeout.yaml" <<'EOF'
+name: bad-timeout
+health_timeout: soon
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: a, port: 8000}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/bad-timeout.yaml" --dry-run 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"health_timeout"* ]]; then
+    log_pass "bad health_timeout errors naming the field"
+else
+    log_fail "bad health_timeout errors naming the field (rc=$RC)"
+    log_verbose "$OUT"
+fi
+
+# ---- 12. --dry-run conflicts with --stop ----
+log_test "--dry-run cannot be combined with --stop"
+OUT="$("$RUN_STACK" example-dual-stack --stop --dry-run 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"not allowed with"* ]]; then
+    log_pass "--stop --dry-run is rejected"
+else
+    log_fail "--stop --dry-run is rejected (rc=$RC)"
+    log_verbose "$OUT"
+fi
+
+# ---- 13. derived container names keep dotted recipe names intact ----
+log_test "shorthand entry derives the full recipe name"
+cat > "$TMPDIR_STACK/shorthand.yaml" <<'EOF'
+name: shorthand
+recipes:
+  - qwen3.6-35b-a3b-nvfp4
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/shorthand.yaml" --dry-run \
+        --config "$TMPDIR_STACK/empty.env" 2>&1)"
+assert_contains "derived name is not truncated at the first dot" "$OUT" \
+    "--name qwen3.6-35b-a3b-nvfp4"
+
+# ---- 14. --dry-run reflects --setup ----
+log_test "--dry-run --setup shows the --setup flag"
+OUT="$("$RUN_STACK" example-dual-stack --dry-run --setup \
+        --config "$TMPDIR_STACK/empty.env" 2>&1)"; RC=$?
+# Scope the needle to the generated command lines: argparse's own
+# "unrecognized arguments: --setup" error would satisfy a bare-string match,
+# turning this test false-green if the flag were removed from the parser.
+PLAN_LINES="$(echo "$OUT" | grep './run-recipe.py')"
+if [[ $RC -eq 0 && -n "$PLAN_LINES" && "$PLAN_LINES" == *"--setup"* ]]; then
+    log_pass "planned run-recipe.py commands include --setup"
+else
+    log_fail "planned run-recipe.py commands include --setup (rc=$RC)"
+    log_verbose "$OUT"
+fi
+
+# ---- 15. missing recipe field is rejected ----
+log_test "entry without 'recipe' is rejected"
+cat > "$TMPDIR_STACK/no-recipe.yaml" <<'EOF'
+name: no-recipe
+recipes:
+  - {container_name: a, port: 8000}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/no-recipe.yaml" --dry-run 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"must have a 'recipe'"* ]]; then
+    log_pass "missing recipe field errors"
+else
+    log_fail "missing recipe field errors (rc=$RC)"
+    log_verbose "$OUT"
+fi
+
+# ---- fixtures reused by several tests below: a cluster .env and a
+# cluster-capable stack (placement resolution replaces the old stack-wide
+# Mode: SOLO/CLUSTER banner tests; see P1-P6 for placement coverage) ----
+cat > "$TMPDIR_STACK/cluster.env" <<'EOF'
+CLUSTER_NODES="10.0.0.1,10.0.0.2"
+LOCAL_IP="10.0.0.1"
+EOF
+cat > "$TMPDIR_STACK/clusterable.yaml" <<'EOF'
+name: clusterable
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: a, port: 8000}
+EOF
+
+# ---- 19. master_port auto-assigns and can be overridden ----
+log_test "master_port auto-assignment and override"
+cat > "$TMPDIR_STACK/mports.yaml" <<'EOF'
+name: mports
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: a, port: 8000}
+  - {recipe: gemma4-26b-a4b, container_name: b, port: 8001}
+  - {recipe: qwen3.5-35b-a3b-fp8, container_name: c, port: 8002, master_port: 29600}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/mports.yaml" --dry-run \
+        --config "$TMPDIR_STACK/cluster.env" 2>&1)"
+log_verbose "$OUT"
+assert_contains "entry 1 auto master port" "$OUT" "--master-port 29501"
+assert_contains "entry 2 auto master port" "$OUT" "--master-port 29502"
+assert_contains "entry 3 explicit override wins" "$OUT" "--master-port 29600"
+
+# ---- 20. duplicate master_port rejected ----
+log_test "duplicate master_port is rejected"
+cat > "$TMPDIR_STACK/dup-mport.yaml" <<'EOF'
+name: dup-mport
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: a, port: 8000, master_port: 29501}
+  - {recipe: gemma4-26b-a4b, container_name: b, port: 8001, master_port: 29501}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/dup-mport.yaml" --dry-run \
+        --config "$TMPDIR_STACK/cluster.env" 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"master_port 29501 duplicates"* ]]; then
+    log_pass "duplicate master_port errors with nonzero exit"
+else
+    log_fail "duplicate master_port errors with nonzero exit (rc=$RC)"
+    log_verbose "$OUT"
+fi
+
+# ---- 21. master_port colliding with an API port rejected ----
+log_test "master_port colliding with an API port is rejected"
+cat > "$TMPDIR_STACK/mport-clash.yaml" <<'EOF'
+name: mport-clash
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: a, port: 8000, master_port: 8001}
+  - {recipe: gemma4-26b-a4b, container_name: b, port: 8001}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/mport-clash.yaml" --dry-run \
+        --config "$TMPDIR_STACK/cluster.env" 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"collides with an API port"* ]]; then
+    log_pass "master_port/API port collision errors"
+else
+    log_fail "master_port/API port collision errors (rc=$RC)"
+    log_verbose "$OUT"
+fi
+
+# ---- 22. non-integer master_port names the field ----
+log_test "non-integer master_port is rejected"
+cat > "$TMPDIR_STACK/bad-mport.yaml" <<'EOF'
+name: bad-mport
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: a, port: 8000, master_port: soon}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/bad-mport.yaml" --dry-run \
+        --config "$TMPDIR_STACK/cluster.env" 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"master_port"* && "$OUT" != *"Traceback"* ]]; then
+    log_pass "bad master_port errors naming the field"
+else
+    log_fail "bad master_port errors naming the field (rc=$RC)"
+    log_verbose "$OUT"
+fi
+
+# ---- 22b. an explicit master_port equal to the 29501 default survives a
+# differing .env MASTER_PORT (launch-cluster.sh honors any passed value; the
+# .env applies only when no --master-port is passed at all) ----
+log_test "explicit master_port 29501 coexists with a differing .env MASTER_PORT"
+cat > "$TMPDIR_STACK/mport-override.env" <<'EOF'
+CLUSTER_NODES="10.0.0.1,10.0.0.2"
+LOCAL_IP="10.0.0.1"
+MASTER_PORT=29500
+EOF
+cat > "$TMPDIR_STACK/mport-override.yaml" <<'EOF'
+name: mport-override
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: a, port: 8000}
+  - {recipe: gemma4-26b-a4b, container_name: b, port: 8001, master_port: 29501}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/mport-override.yaml" --dry-run \
+        --config "$TMPDIR_STACK/mport-override.env" 2>&1)"; RC=$?
+if [[ $RC -eq 0 && "$OUT" == *"--master-port 29500"* && "$OUT" == *"--master-port 29501"* ]]; then
+    log_pass ".env base auto-assigns 29500; explicit 29501 passes through"
+else
+    log_fail ".env base auto-assigns 29500; explicit 29501 passes through (rc=$RC)"
+    log_verbose "$OUT"
+fi
+
+# ---- 22e. a nonexistent --config path is an error, not an empty env ----
+log_test "nonexistent --config path is rejected"
+OUT="$("$RUN_STACK" example-cluster-stack --dry-run \
+        --config /nonexistent/typo.env 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"Error:"* && "$OUT" == *"/nonexistent/typo.env"* \
+      && "$OUT" != *"=== Stack:"* ]]; then
+    log_pass "typo'd --config errors instead of silently resolving"
+else
+    log_fail "typo'd --config errors instead of silently resolving (rc=$RC)"
+    log_verbose "$OUT"
+fi
+
+# ---- 22f. out-of-range master_port is rejected (0 would be silently dropped) ----
+log_test "master_port 0 is rejected"
+cat > "$TMPDIR_STACK/mport-zero.yaml" <<'EOF'
+name: mport-zero
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: a, port: 8000}
+  - {recipe: gemma4-26b-a4b, container_name: b, port: 8001, master_port: 0}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/mport-zero.yaml" --dry-run \
+        --config "$TMPDIR_STACK/cluster.env" 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"'master_port' must be between 1 and 65535"* \
+      && "$OUT" != *"Traceback"* ]]; then
+    log_pass "master_port 0 errors instead of silently colliding"
+else
+    log_fail "master_port 0 errors instead of silently colliding (rc=$RC)"
+    log_verbose "$OUT"
+fi
+
+# ---- 22g. YAML boolean port is rejected (true would become --port 1) ----
+log_test "boolean port is rejected"
+cat > "$TMPDIR_STACK/port-bool.yaml" <<'EOF'
+name: port-bool
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: a, port: true}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/port-bool.yaml" --dry-run \
+        --config "$TMPDIR_STACK/empty.env" 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"'port' must be an integer"* \
+      && "$OUT" != *"Traceback"* ]]; then
+    log_pass "boolean port errors instead of becoming --port 1"
+else
+    log_fail "boolean port errors instead of becoming --port 1 (rc=$RC)"
+    log_verbose "$OUT"
+fi
+
+# ---- 23. cluster mode emits -n and --master-port, never --solo ----
+log_test "cluster dry-run emits -n and omits --solo"
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/clusterable.yaml" --dry-run \
+        --config "$TMPDIR_STACK/cluster.env" 2>&1)"
+log_verbose "$OUT"
+assert_contains "node list passed explicitly" "$OUT" "-n 10.0.0.1,10.0.0.2"
+assert_contains "master port passed" "$OUT" "--master-port 29501"
+# The explicit --config must be forwarded to each run-recipe.py invocation so
+# every entry resolves the same .env the stack itself used.
+CONFIG_LINES="$(echo "$OUT" | grep './run-recipe.py')"
+if [[ "$CONFIG_LINES" == *"--config"*"cluster.env"* ]]; then
+    log_pass "--config forwarded on the run-recipe.py plan line"
+else
+    log_fail "--config forwarded on the run-recipe.py plan line"
+    log_verbose "$CONFIG_LINES"
+fi
+# Scope the --solo check to the generated command lines only. A blanket
+# `$OUT != *--solo*` would break the moment any banner or hint text mentions
+# the flag, which is unrelated to what gets executed.
+PLAN_LINES="$(echo "$OUT" | grep './run-recipe.py')"
+if [[ -n "$PLAN_LINES" && "$PLAN_LINES" != *"--solo"* ]]; then
+    log_pass "cluster plan commands contain no --solo"
+else
+    log_fail "cluster plan commands contain no --solo"
+    log_verbose "$PLAN_LINES"
+fi
+
+# (Former tests 24-26 covered stack-wide mode contradictions; per-entry
+# placement coverage now lives in P11-P13.)
+
+# ---- 26b. malformed recipe YAML fails loudly instead of bypassing mode validation ----
+log_test "malformed recipe YAML is rejected, not silently defaulted"
+printf 'cluster_only: [\n  broken' > "$TMPDIR_STACK/broken-recipe.yaml"
+cat > "$TMPDIR_STACK/broken-ref.yaml" <<EOF
+name: broken-ref
+recipes:
+  - {recipe: $TMPDIR_STACK/broken-recipe.yaml, container_name: a, port: 8000}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/broken-ref.yaml" --dry-run \
+        --config "$TMPDIR_STACK/empty.env" 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"could not be read"* && "$OUT" != *"Traceback"* ]]; then
+    log_pass "malformed recipe YAML errors instead of defaulting to no mode restriction"
+else
+    log_fail "malformed recipe YAML errors instead of defaulting to no mode restriction (rc=$RC)"
+    log_verbose "$OUT"
+fi
+
+# ---- 26b2. recipe YAML that parses to a non-mapping fails like unreadable YAML ----
+log_test "list-shaped recipe YAML is rejected, not silently defaulted"
+printf -- '- just\n- a list\n' > "$TMPDIR_STACK/list-recipe.yaml"
+cat > "$TMPDIR_STACK/list-ref.yaml" <<EOF
+name: list-ref
+recipes:
+  - {recipe: $TMPDIR_STACK/list-recipe.yaml, container_name: a, port: 8000}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/list-ref.yaml" --dry-run \
+        --config "$TMPDIR_STACK/empty.env" 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"could not be read"* && "$OUT" != *"Traceback"* ]]; then
+    log_pass "list-shaped recipe YAML errors instead of bypassing mode validation"
+else
+    log_fail "list-shaped recipe YAML errors instead of bypassing mode validation (rc=$RC)"
+    log_verbose "$OUT"
+fi
+
+# ---- 26c. a recipe's cluster_only/solo_only flag must NOT block --status ----
+log_test "--status is not blocked by a recipe mode flag"
+cat > "$TMPDIR_STACK/co.yaml" <<'EOF'
+name: co
+recipes:
+  - {recipe: deepseek-v4-flash, container_name: a, port: 8000}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/co.yaml" --status \
+        --config "$TMPDIR_STACK/empty.env" 2>&1)"; RC=$?
+if [[ $RC -eq 0 && "$OUT" == *"deepseek-v4-flash"* && "$OUT" != *"cluster_only"* ]]; then
+    log_pass "--status inspects a contradictory stack instead of refusing"
+else
+    log_fail "--status inspects a contradictory stack instead of refusing (rc=$RC)"
+    log_verbose "$OUT"
+fi
+
+# (Former test 27 covered stop_command; P15 below covers all its placement
+# forms plus --config forwarding.)
+
+# ---- P1. placement: all distributes across the .env cluster ----
+log_test "placement all -> distributed"
+cat > "$TMPDIR_STACK/cluster.env" <<'EOF'
+CLUSTER_NODES="10.0.0.1,10.0.0.2"
+LOCAL_IP="10.0.0.1"
+EOF
+cat > "$TMPDIR_STACK/p-all.yaml" <<'EOF'
+name: p-all
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: a, port: 8000, placement: all}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/p-all.yaml" --dry-run --config "$TMPDIR_STACK/cluster.env" 2>&1)"
+log_verbose "$OUT"
+assert_contains "distributed emits -n" "$OUT" "-n 10.0.0.1,10.0.0.2"
+assert_contains "distributed emits master-port" "$OUT" "--master-port 29501"
+
+# ---- P2. placement: all, no cluster -> solo local (byte-identical solo form) ----
+log_test "placement all, no cluster -> solo local"
+: > "$TMPDIR_STACK/empty.env"
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/p-all.yaml" --dry-run --config "$TMPDIR_STACK/empty.env" 2>&1)"
+log_verbose "$OUT"
+assert_contains "solo local emits --solo" "$OUT" \
+    "./run-recipe.py qwen3.6-35b-a3b-nvfp4 --solo --name a -d --port 8000"
+
+# ---- P2a. 'all' means every available node, so on a single-node host it is
+# the expected placement, not a fault: no warning. Covers both spellings --
+# the omitted key AND an explicit 'placement: all' -- on the read-only
+# sub-commands (up/--stop have side effects and are exercised elsewhere). ----
+log_test "no-cluster fallback reports placement without warning"
+cat > "$TMPDIR_STACK/p-default.yaml" <<'EOF'
+name: p-default
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: a, port: 8000}
+EOF
+for STACK_YAML in "$TMPDIR_STACK/p-default.yaml" "$TMPDIR_STACK/p-all.yaml"; do
+    for MODE in --dry-run --status; do
+        LABEL="$(basename "$STACK_YAML" .yaml) $MODE"
+        OUT="$("$RUN_STACK" "$STACK_YAML" "$MODE" \
+                --config "$TMPDIR_STACK/empty.env" 2>&1)"
+        log_verbose "$OUT"
+        assert_contains "$LABEL names the placement target" "$OUT" "-> this host"
+        if [[ "$OUT" != *"WARNING"* ]]; then
+            log_pass "$LABEL emits no fallback warning"
+        else
+            log_fail "$LABEL emits no fallback warning"
+            log_verbose "$OUT"
+        fi
+    done
+done
+
+# ---- P3. placement: <local IP> -> solo on this host ----
+log_test "placement local IP -> solo local"
+cat > "$TMPDIR_STACK/p-local.yaml" <<'EOF'
+name: p-local
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: a, port: 8000, placement: 10.0.0.1}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/p-local.yaml" --dry-run --config "$TMPDIR_STACK/cluster.env" 2>&1)"
+assert_contains "local placement emits --solo" "$OUT" \
+    "./run-recipe.py qwen3.6-35b-a3b-nvfp4 --solo --name a -d --port 8000"
+
+# ---- P4. placement: <remote IP> -> --placement-node, never --solo ----
+log_test "placement remote IP -> --placement-node"
+cat > "$TMPDIR_STACK/p-remote.yaml" <<'EOF'
+name: p-remote
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: a, port: 8000, placement: 10.0.0.2}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/p-remote.yaml" --dry-run --config "$TMPDIR_STACK/cluster.env" 2>&1)"
+log_verbose "$OUT"
+assert_contains "remote placement emits --placement-node" "$OUT" \
+    "./run-recipe.py qwen3.6-35b-a3b-nvfp4 --placement-node 10.0.0.2 --name a -d --port 8000"
+PLAN_LINES="$(echo "$OUT" | grep './run-recipe.py')"
+if [[ -n "$PLAN_LINES" && "$PLAN_LINES" != *"--solo"* ]]; then
+    log_pass "remote placement plan contains no --solo"
+else log_fail "remote placement plan contains no --solo"; log_verbose "$PLAN_LINES"; fi
+assert_contains "remote entry health-polls its node, not localhost" "$OUT" "http://10.0.0.2:8000/health"
+
+# ---- P5. placement naming an unknown node is rejected at load time ----
+log_test "unknown placement IP is rejected"
+cat > "$TMPDIR_STACK/p-bad.yaml" <<'EOF'
+name: p-bad
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: a, port: 8000, placement: 10.9.9.9}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/p-bad.yaml" --dry-run --config "$TMPDIR_STACK/cluster.env" 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"10.9.9.9"* && "$OUT" == *"placement"* && "$OUT" != *"Traceback"* ]]; then
+    log_pass "unknown placement node errors, naming the IP"
+else log_fail "unknown placement node errors, naming the IP (rc=$RC)"; log_verbose "$OUT"; fi
+
+# ---- P6. mixed stack: one distributed, one pinned remote (distinct ports) ----
+log_test "mixed placement in one stack"
+cat > "$TMPDIR_STACK/p-mixed.yaml" <<'EOF'
+name: p-mixed
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: big, port: 8000, placement: all}
+  - {recipe: gemma4-26b-a4b, container_name: small, port: 8001, placement: 10.0.0.2}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/p-mixed.yaml" --dry-run --config "$TMPDIR_STACK/cluster.env" 2>&1)"
+log_verbose "$OUT"
+assert_contains "big is distributed" "$OUT" "qwen3.6-35b-a3b-nvfp4 -n 10.0.0.1,10.0.0.2"
+assert_contains "small is pinned remote" "$OUT" "gemma4-26b-a4b --placement-node 10.0.0.2"
+
+# ---- P16. a non-string placement (e.g. a list for a subset) is rejected cleanly ----
+log_test "non-string placement is rejected without a traceback"
+cat > "$TMPDIR_STACK/p-listplace.yaml" <<'EOF'
+name: p-listplace
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: a, port: 8000, placement: [10.0.0.1, 10.0.0.2]}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/p-listplace.yaml" --dry-run --config "$TMPDIR_STACK/cluster.env" 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"placement"* && "$OUT" != *"Traceback"* ]]; then
+    log_pass "non-string placement errors cleanly, naming the field"
+else
+    log_fail "non-string placement errors cleanly, naming the field (rc=$RC)"; log_verbose "$OUT"
+fi
+
+# ---- P7. same API port on different nodes is allowed ----
+log_test "same port on different nodes is allowed"
+cat > "$TMPDIR_STACK/p-ports-ok.yaml" <<'EOF'
+name: p-ports-ok
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: a, port: 8000, placement: 10.0.0.1}
+  - {recipe: gemma4-26b-a4b, container_name: b, port: 8000, placement: 10.0.0.2}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/p-ports-ok.yaml" --dry-run --config "$TMPDIR_STACK/cluster.env" 2>&1)"; RC=$?
+if [[ $RC -eq 0 ]]; then log_pass "same port, different nodes accepted"
+else log_fail "same port, different nodes accepted (rc=$RC)"; log_verbose "$OUT"; fi
+
+# ---- P8. same API port on the SAME node is rejected ----
+log_test "duplicate port on the same node is rejected"
+cat > "$TMPDIR_STACK/p-ports-bad.yaml" <<'EOF'
+name: p-ports-bad
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: a, port: 8000, placement: 10.0.0.2}
+  - {recipe: gemma4-26b-a4b, container_name: b, port: 8000, placement: 10.0.0.2}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/p-ports-bad.yaml" --dry-run --config "$TMPDIR_STACK/cluster.env" 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"port 8000"* && "$OUT" == *"10.0.0.2"* ]]; then
+    log_pass "duplicate port on one node rejected"
+else log_fail "duplicate port on one node rejected (rc=$RC)"; log_verbose "$OUT"; fi
+
+# ---- P9. single-node entries may reuse a master_port value (unused) ----
+log_test "single-node entries need no distinct master_port"
+cat > "$TMPDIR_STACK/p-mp-single.yaml" <<'EOF'
+name: p-mp-single
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: a, port: 8000, placement: 10.0.0.1, master_port: 29501}
+  - {recipe: gemma4-26b-a4b, container_name: b, port: 8001, placement: 10.0.0.2, master_port: 29501}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/p-mp-single.yaml" --dry-run --config "$TMPDIR_STACK/cluster.env" 2>&1)"; RC=$?
+if [[ $RC -eq 0 ]]; then log_pass "single-node master_port reuse accepted"
+else log_fail "single-node master_port reuse accepted (rc=$RC)"; log_verbose "$OUT"; fi
+
+# ---- P10. two DISTRIBUTED entries sharing a master_port is rejected ----
+log_test "duplicate master_port among distributed entries is rejected"
+cat > "$TMPDIR_STACK/p-mp-dist.yaml" <<'EOF'
+name: p-mp-dist
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: a, port: 8000, placement: all, master_port: 29501}
+  - {recipe: gemma4-26b-a4b, container_name: b, port: 8001, placement: all, master_port: 29501}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/p-mp-dist.yaml" --dry-run --config "$TMPDIR_STACK/cluster.env" 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"master_port"* ]]; then log_pass "duplicate distributed master_port rejected"
+else log_fail "duplicate distributed master_port rejected (rc=$RC)"; log_verbose "$OUT"; fi
+
+# ---- P11. cluster_only recipe pinned to a single node is rejected ----
+log_test "cluster_only + single-node placement rejected"
+cat > "$TMPDIR_STACK/p-co.yaml" <<'EOF'
+name: p-co
+recipes:
+  - {recipe: deepseek-v4-flash, container_name: a, port: 8000, placement: 10.0.0.2}
+EOF
+# Exit code 3 is the CI contract: the workflow retries a mode-conflicting
+# stack without a cluster only when it sees 3, so pin the exact code here.
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/p-co.yaml" --dry-run --config "$TMPDIR_STACK/cluster.env" 2>&1)"; RC=$?
+if [[ $RC -eq 3 && "$OUT" == *"cluster_only"* && "$OUT" == *"deepseek-v4-flash"* ]]; then
+    log_pass "cluster_only + single-node rejected with exit code 3"
+else log_fail "cluster_only + single-node rejected with exit code 3 (rc=$RC)"; log_verbose "$OUT"; fi
+
+# ---- P12. solo_only recipe that resolves distributed is rejected ----
+log_test "solo_only + distributed rejected"
+cat > "$TMPDIR_STACK/p-so.yaml" <<'EOF'
+name: p-so
+recipes:
+  - {recipe: openai-gpt-oss-120b, container_name: a, port: 8000, placement: all}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/p-so.yaml" --dry-run --config "$TMPDIR_STACK/cluster.env" 2>&1)"; RC=$?
+if [[ $RC -eq 3 && "$OUT" == *"solo_only"* && "$OUT" == *"openai-gpt-oss-120b"* ]]; then
+    log_pass "solo_only + distributed rejected with exit code 3"
+else log_fail "solo_only + distributed rejected with exit code 3 (rc=$RC)"; log_verbose "$OUT"; fi
+
+# ---- P13. solo_only recipe pinned to a single node is fine ----
+log_test "solo_only + single-node accepted"
+cat > "$TMPDIR_STACK/p-so-ok.yaml" <<'EOF'
+name: p-so-ok
+recipes:
+  - {recipe: openai-gpt-oss-120b, container_name: a, port: 8000, placement: 10.0.0.2}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/p-so-ok.yaml" --dry-run --config "$TMPDIR_STACK/cluster.env" 2>&1)"; RC=$?
+if [[ $RC -eq 0 ]]; then log_pass "solo_only + single-node accepted"
+else log_fail "solo_only + single-node accepted (rc=$RC)"; log_verbose "$OUT"; fi
+
+# ---- P14. --status is NOT blocked by a contradiction (LOCAL-resolving; no ssh) ----
+log_test "--status not blocked by a placement contradiction (local)"
+cat > "$TMPDIR_STACK/p-co-local.yaml" <<'EOF'
+name: p-co-local
+recipes:
+  - {recipe: deepseek-v4-flash, container_name: a, port: 8000, placement: all}
+EOF
+# empty.env -> no cluster -> resolves single-LOCAL, so --status does only local
+# docker inspect + localhost health, never an ssh.
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/p-co-local.yaml" --status --config "$TMPDIR_STACK/empty.env" 2>&1)"; RC=$?
+if [[ $RC -eq 0 && "$OUT" == *"deepseek-v4-flash"* && "$OUT" != *"cluster_only"* ]]; then
+    log_pass "--status inspects a contradictory (local) stack instead of refusing"
+else log_fail "--status inspects a contradictory (local) stack instead of refusing (rc=$RC)"; log_verbose "$OUT"; fi
+
+# ---- P15. stop_command renders per placement, and forwards --config ----
+log_test "stop_command distributed/local/remote argv"
+OUT="$(python3 - "$PROJECT_DIR" <<'PY'
+import sys, importlib.util
+from pathlib import Path
+root = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("rs", root / "run-stack.py")
+rs = importlib.util.module_from_spec(spec); spec.loader.exec_module(rs)
+P = rs.Placement
+def entry(p): return {"container_name": "a", "placement": p, "master_port": 29501}
+print("DIST:", rs.stop_command(entry(P("distributed", ["10.0.0.1","10.0.0.2"], None, ""))))
+print("LOCAL:", rs.stop_command(entry(P("single", [], None, ""))))
+print("REMOTE:", rs.stop_command(entry(P("single", [], "10.0.0.2", "")), "/x/.env"))
+PY
+)"
+log_verbose "$OUT"
+assert_contains "distributed stop passes -n" "$OUT" "'-n', '10.0.0.1,10.0.0.2', '--name', 'a', 'stop'"
+assert_contains "local stop keeps --solo" "$OUT" "'--solo', '--name', 'a', 'stop'"
+assert_contains "remote stop passes --placement-node" "$OUT" "'--placement-node', '10.0.0.2'"
+assert_contains "remote stop forwards --config" "$OUT" "'--config', '/x/.env'"
+if [[ "$OUT" != *"REMOTE:"*"--solo"* ]]; then log_pass "remote stop omits --solo"
+else log_fail "remote stop omits --solo"; log_verbose "$OUT"; fi
+# The load-bearing invariant: a distributed stop must NEVER pass --solo, or
+# launch-cluster.sh's cleanup skips its ssh worker loop and strands worker
+# containers. Require the DIST line to be present AND free of --solo (so this
+# cannot pass vacuously when stop_command errors before printing).
+DIST_LINE="$(echo "$OUT" | grep '^DIST:')"
+if [[ -n "$DIST_LINE" && "$DIST_LINE" != *"--solo"* ]]; then
+    log_pass "distributed stop omits --solo (no worker stranding)"
+else
+    log_fail "distributed stop omits --solo (no worker stranding)"; log_verbose "$DIST_LINE"
+fi
+
+# ---- V1. absolute host paths pass through; -v lands before the `--` ----
+log_test "volumes: absolute host path renders as -v before extra_args"
+cat > "$TMPDIR_STACK/vol-abs.yaml" <<'EOF'
+name: vol-abs
+recipes:
+  - recipe: qwen3.6-35b-a3b-nvfp4
+    container_name: q
+    port: 8000
+    volumes: ["/data/models:/models", "/data/out:/out:ro"]
+    extra_args: ["--load-format", "instanttensor"]
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/vol-abs.yaml" --dry-run \
+        --config "$TMPDIR_STACK/empty.env" 2>&1)"
+log_verbose "$OUT"
+assert_contains "absolute host path unchanged" "$OUT" "-v /data/models:/models"
+assert_contains ":ro option suffix preserved" "$OUT" "-v /data/out:/out:ro"
+# -v must precede the `--` separator or run-recipe.py would hand it to vLLM.
+if [[ "$OUT" == *"-v /data/models:/models"*"-- --load-format"* ]]; then
+    log_pass "-v precedes the -- extra_args separator"
+else
+    log_fail "-v precedes the -- extra_args separator"; log_verbose "$OUT"
+fi
+
+# ---- V2. relative host paths resolve against the repo root (as mods do) ----
+log_test "volumes: relative host path resolves to an absolute path"
+cat > "$TMPDIR_STACK/vol-rel.yaml" <<'EOF'
+name: vol-rel
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: q, port: 8000, volumes: ["data/models:/models"]}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/vol-rel.yaml" --dry-run \
+        --config "$TMPDIR_STACK/empty.env" 2>&1)"
+log_verbose "$OUT"
+assert_contains "relative host path made absolute" "$OUT" \
+    "-v $PROJECT_DIR/data/models:/models"
+
+# ---- V3. a bare name (no slash) stays a named Docker volume ----
+log_test "volumes: bare name is left as a named Docker volume"
+cat > "$TMPDIR_STACK/vol-named.yaml" <<'EOF'
+name: vol-named
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: q, port: 8000, volumes: ["hfcache:/root/.cache/huggingface"]}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/vol-named.yaml" --dry-run \
+        --config "$TMPDIR_STACK/empty.env" 2>&1)"
+log_verbose "$OUT"
+assert_contains "named volume not path-resolved" "$OUT" \
+    "-v hfcache:/root/.cache/huggingface"
+if [[ "$OUT" != *"$PROJECT_DIR/hfcache"* ]]; then
+    log_pass "named volume not rewritten to a repo-relative path"
+else
+    log_fail "named volume not rewritten to a repo-relative path"; log_verbose "$OUT"
+fi
+
+# ---- V4. a relative CONTAINER path is rejected (Docker requires absolute) ----
+log_test "volumes: relative container path is rejected"
+cat > "$TMPDIR_STACK/vol-badtarget.yaml" <<'EOF'
+name: vol-badtarget
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: q, port: 8000, volumes: ["/data/models:models"]}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/vol-badtarget.yaml" --dry-run 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"container path"* && "$OUT" == *"absolute"* ]]; then
+    log_pass "relative container path errors with nonzero exit"
+else
+    log_fail "relative container path errors with nonzero exit (rc=$RC)"
+    log_verbose "$OUT"
+fi
+
+# ---- V5. a mapping with no container path is rejected ----
+log_test "volumes: mapping without a container path is rejected"
+cat > "$TMPDIR_STACK/vol-nocolon.yaml" <<'EOF'
+name: vol-nocolon
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: q, port: 8000, volumes: ["/data/models"]}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/vol-nocolon.yaml" --dry-run 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"host:container"* ]]; then
+    log_pass "missing container path errors with nonzero exit"
+else
+    log_fail "missing container path errors with nonzero exit (rc=$RC)"
+    log_verbose "$OUT"
+fi
+
+# ---- V6. volumes are forwarded per entry, not leaked across entries ----
+log_test "volumes: applied only to the entry that declares them"
+cat > "$TMPDIR_STACK/vol-scope.yaml" <<'EOF'
+name: vol-scope
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: q, port: 8000, volumes: ["/data/a:/a"]}
+  - {recipe: nemotron-3-nano-nvfp4, container_name: n, port: 8001}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/vol-scope.yaml" --dry-run \
+        --config "$TMPDIR_STACK/empty.env" 2>&1)"
+log_verbose "$OUT"
+ENTRY2="$(echo "$OUT" | grep 'run-recipe.py nemotron-3-nano-nvfp4')"
+if [[ -n "$ENTRY2" && "$ENTRY2" != *"-v "* ]]; then
+    log_pass "entry without volumes gets no -v"
+else
+    log_fail "entry without volumes gets no -v"; log_verbose "$ENTRY2"
+fi
+
+# ---- V7. a non-list 'volumes:' is rejected cleanly, not with a traceback ----
+log_test "volumes: non-list value is rejected cleanly"
+cat > "$TMPDIR_STACK/vol-notlist.yaml" <<'EOF'
+name: vol-notlist
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: q, port: 8000, volumes: "/data/models:/models"}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/vol-notlist.yaml" --dry-run 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"Error:"* && "$OUT" == *"must be a list"* && "$OUT" != *"Traceback"* ]]; then
+    log_pass "non-list volumes errors without a traceback"
+else
+    log_fail "non-list volumes errors without a traceback (rc=$RC)"
+    log_verbose "$OUT"
+fi
+
+# ---- V8. '~' expands; an unknown ~user is rejected cleanly, not a traceback ----
+log_test "volumes: ~ expands and an unknown ~user is rejected cleanly"
+cat > "$TMPDIR_STACK/vol-tilde.yaml" <<'EOF'
+name: vol-tilde
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: q, port: 8000, volumes: ["~/models:/models"]}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/vol-tilde.yaml" --dry-run \
+        --config "$TMPDIR_STACK/empty.env" 2>&1)"
+assert_contains "~ expands to \$HOME" "$OUT" "-v $HOME/models:/models"
+cat > "$TMPDIR_STACK/vol-baduser.yaml" <<'EOF'
+name: vol-baduser
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: q, port: 8000, volumes: ["~nosuchuser42/models:/models"]}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/vol-baduser.yaml" --dry-run 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"Error:"* && "$OUT" != *"Traceback"* ]]; then
+    log_pass "unknown ~user errors without a traceback"
+else
+    log_fail "unknown ~user errors without a traceback (rc=$RC)"
+    log_verbose "$OUT"
+fi
+
+# ---- V9. shell metacharacters are refused at load time ----
+# launch-cluster.sh expands $DOCKER_ARGS unquoted and re-parses the docker line
+# through bash -c/ssh, so a space or a $ in a mapping would word-split or
+# execute rather than mount. Refuse it here with a readable message instead.
+log_test "volumes: whitespace / shell metacharacters are rejected"
+cat > "$TMPDIR_STACK/vol-space.yaml" <<'EOF'
+name: vol-space
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: q, port: 8000, volumes: ["/data/my models:/models"]}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/vol-space.yaml" --dry-run 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"Error:"* && "$OUT" != *"Traceback"* ]]; then
+    log_pass "host path with a space is rejected"
+else
+    log_fail "host path with a space is rejected (rc=$RC)"; log_verbose "$OUT"
+fi
+cat > "$TMPDIR_STACK/vol-meta.yaml" <<'EOF'
+name: vol-meta
+recipes:
+  - {recipe: qwen3.6-35b-a3b-nvfp4, container_name: q, port: 8000, volumes: ["/data/$(id -u):/models"]}
+EOF
+OUT="$("$RUN_STACK" "$TMPDIR_STACK/vol-meta.yaml" --dry-run 2>&1)"; RC=$?
+if [[ $RC -ne 0 && "$OUT" == *"Error:"* && "$OUT" != *"Traceback"* ]]; then
+    log_pass "host path with shell metacharacters is rejected"
+else
+    log_fail "host path with shell metacharacters is rejected (rc=$RC)"; log_verbose "$OUT"
+fi
+
+echo "========================================"
+echo -e "Passed: ${GREEN}${TESTS_PASSED}${NC}  Failed: ${RED}${TESTS_FAILED}${NC}"
+echo "========================================"
+[[ $TESTS_FAILED -eq 0 ]]


### PR DESCRIPTION
## Summary

Today this project serves one model at a time: a recipe either runs solo on one box or spreads across the whole cluster, and that decision belongs to the entire launch. This PR adds **stacks** — a declarative manifest that serves several recipes at once, and lets *each one* choose independently where it runs: sharded across every node, or pinned alone to a specific node, local or remote.

```console
$ ./run-stack.sh stacks/example-cluster-stack.yaml
=== Stack: example-cluster-stack (3 recipes) ===
  qwen3.6-35b-a3b-fp8      qwen_fp8      -> distributed across 2 nodes
  nemotron-3-nano-nvfp4    nano-nvfp4    -> this host
  gemma4-26b-a4b-nvfp4     gemma4-nvfp4  -> node 10.0.1.2
```

That is one 35B MoE tensor-parallel across the cluster, plus two single-node models pinned one per node — from a single manifest, with one command. The manifest never says which node is local: whichever `placement:` IP matches `LOCAL_IP` runs here, the other is driven over ssh, so the same file works unchanged from either node.

This directly answers **#273** ("How to use this setup for running multiple LLMs"), where the suggested workaround was launching separate clusters on different ports with hand-balanced memory and a reverse proxy in front. That works, but every model still gets the same placement, memory budgets are the operator's problem, and nothing catches a mistake until something OOMs.

The placement half is worth calling out on its own. `solo_only:` recipes — currently 8 of the 26 in `recipes/` — could not participate in a cluster at all, because the cluster was all-or-nothing. Being able to say *"this model goes on node 2, that one on node 3, and shard the big one over everything"* turns a cluster from one large machine into an addressable pool of nodes, and it is a useful feature entirely on its own, independent of co-locating models on a single box.

Memory is where stacking actually fails, so the driver is built around it: entries are served in the order listed, which must be descending memory usage, and the next launch waits for the previous recipe's `/health`. The largest model therefore profiles free memory against a clean pool and fails fast if it won't fit, and first-time kernel compilation is serialized instead of raced across the shared compile caches.

### Changes

- **`run-stack.py` / `run-stack.sh`** (new): the stack driver. Loads a manifest, resolves each entry's placement, launches sequentially with health gating, and supports `--dry-run`, `--status`, `--stop`, `--setup`, and `--config`. It is a thin layer over `run-recipe.py` and imports it as a module, so both drivers share one `.env` parser, node-list parser, and recipe-path resolution and cannot drift on what a recipe reference means.
- **Per-recipe placement**: `placement: all` shards the recipe across `.env`'s `CLUSTER_NODES`; `placement: <IP>` pins it alone to that node; an omitted key defaults to `all`. `all` means *every node available* — on a single-node host it resolves exactly as if you had pinned `LOCAL_IP`.
- **Load-time validation**, before any container starts: ports are unique **per node** rather than globally (two models on different nodes may share a port); each distributed entry gets its own auto-assigned coordination port so co-located distributed recipes can't collide; a placement IP must be `LOCAL_IP` or a configured node; and a recipe whose `cluster_only:`/`solo_only:` flag contradicts its resolved placement is refused with exit code 3, which CI keys on to retry without a cluster.
- **Placement-aware lifecycle**: `--stop`, `--status`, and health polling each target the entry's own node, so a stack spanning several hosts tears down cleanly instead of stranding worker containers.
- **`launch-cluster.sh`, `run-recipe.py`**: new `--placement-node` flag runs a standalone container on a chosen node, forwarding a solo run over ssh. Additive — existing invocations are unaffected.
- **Per-entry `volumes:`**: forwards Docker `-v host:container[:options]` mounts through `run-recipe.py`, so a stack entry reaches parity with the `-v/--volume` support `launch-cluster.sh` and `run-recipe.py` gained in `e987390`. Relative host paths resolve against the repo root rather than the caller's cwd, the way `mods:` paths do; `~` is expanded; a bare token with no `/` is left alone as a named Docker volume. Load-time validation refuses a relative container path, a malformed mapping, a non-list `volumes:`, and any mapping containing whitespace or shell metacharacters — `launch-cluster.sh` expands mounts unquoted into the `docker run` line, so those would word-split or execute instead of mounting. Mounts are per entry and never leak across recipes.
- **`ensure-python.sh`** (new): shared Python bootstrap extracted from `run-recipe.sh`, so both drivers resolve the interpreter identically.
- **`tests/lib.sh`** (new): shared assertion helpers extracted from the recipe suite.
- **`stacks/README.md`** (new): manifest format, placement semantics, and the memory-budgeting rules.
- **`stacks/example-dual-stack.yaml`, `stacks/example-cluster-stack.yaml`** (new): the two configurations below, as tested, with the per-node memory arithmetic worked out in comments.
- **`.github/workflows/test-recipes.yml`**: runs the new stack suite alongside the recipe suite, watches `run-stack.*` and `stacks/**`, and dry-run-verifies every manifest in `stacks/` against a synthetic 2-node cluster. A stack that exits 3 there is legitimately single-host, so it is re-verified with no cluster configured; any other failure fails CI. This is what keeps a broken example manifest from landing.

### Notes / limitations

- `gpu_mem` is a **per-node** budget, not cluster-wide. Under tensor-parallel sharding each node holds a shard of a distributed model, and that shard shares the node with anything pinned there — the cluster example works this arithmetic out per node.
- Load order is the operator's responsibility. The driver enforces the health gate but cannot know your models' true footprints; listing them out of descending-memory order will still OOM.
- A pinned remote placement requires the same ssh reachability the existing cluster path already assumes.
- `volumes:` host paths are resolved on the machine running `run-stack` but mounted on the placement node. `placement: all` applies the same `-v` to every node, so the path must exist cluster-wide; a `placement: <IP>` entry has the same trap in smaller form, since a relative or `~` path is expanded locally and then shipped over ssh. Docker does not fail on a missing host path — it creates an empty root-owned directory and mounts that — so the README recommends absolute paths for anything non-local. This matches how the repo already treats the HF/compile cache mounts, which assume the same path on every node. `-p/--publish` is deliberately **not** exposed per entry: it swaps the container off `--network host` onto bridge networking and is solo-only, which would break the per-node port-uniqueness invariant and the `/health` polling that stacks depend on. Per-entry `port:` already gives each model its own host port.
- Stacks are additive. Nothing about the existing single-recipe workflow changes.

## Test plan

- [x] `tests/test_stack.sh` — 86/86 on the branch (new suite: manifest validation, placement resolution, per-node port/coordination-port collision, mode-flag conflicts, `volumes:` rendering and rejection cases, teardown)
- [x] `tests/test_recipes.sh` — 65/65 on the branch, so existing recipe workflows are unregressed (includes the two `-v` tests added upstream in `e987390`)
- [x] Real hardware, **1× DGX Spark**: `example-dual-stack.yaml` with no `.env` — both models co-resident on one box
- [x] Real hardware, **2-node cluster**: `example-cluster-stack.yaml` — one model sharded across both nodes plus two `solo_only` models pinned one per node, all three serving concurrently
- [x] Real hardware, **4-node cluster**: cluster-wide placement, single-node placement, and mixed combinations of the two
- [x] Verified `--dry-run` renders the exact `run-recipe.py` command line and resolved placement for every entry before anything allocates memory
- [x] Verified `--status` and `--stop` reach containers on remote pinned nodes, and that a distributed stop does not strand worker containers
- [x] `volumes:` is covered by `--dry-run` argv assertions only (rendering, repo-relative resolution, named-volume passthrough, rejection of relative/missing container paths). The hardware runs above predate it; the flag it emits is the same `-v` `launch-cluster.sh` already exercises.

