### PR TITLE
Support building vLLM from a fork (VLLM_REPO, SETUPTOOLS_SCM_PRETEND_VERSION)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -242,6 +242,9 @@ WORKDIR $VLLM_BASE_DIR
 # --- VLLM SOURCE CACHE BUSTER ---
 ARG CACHEBUST_VLLM=1
 
+# Upstream repository to build from. Parameterized so the image can be built from a
+# fork -- e.g. hardware-enablement branches that are not merged upstream yet.
+ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 # Git reference (branch, tag, or SHA) to checkout
 ARG VLLM_REF=main
 
@@ -257,7 +260,7 @@ RUN --mount=type=cache,id=repo-cache,target=/repo-cache \
     cd /repo-cache && \
     if [ ! -d "vllm" ]; then \
         echo "Cache miss: Cloning vLLM from scratch..." && \
-        git clone --recursive https://github.com/vllm-project/vllm.git; \
+        git clone --recursive ${VLLM_REPO} vllm; \
         if [ "$VLLM_REF" != "main" ]; then \
             cd vllm && \
             git checkout ${VLLM_REF}; \
@@ -265,6 +268,7 @@ RUN --mount=type=cache,id=repo-cache,target=/repo-cache \
     else \
         echo "Cache hit: Fetching updates..." && \
         cd vllm && \
+        git remote set-url origin ${VLLM_REPO} && \
         git fetch origin && \
         git fetch origin --tags --force && \
         (git checkout --detach origin/${VLLM_REF} 2>/dev/null || git checkout ${VLLM_REF}) && \
@@ -877,13 +881,21 @@ RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
 # RUN curl -L https://patch-diff.githubusercontent.com/raw/vllm-project/vllm/pull/34758.diff | patch -p1 -R || echo "Cannot revert PR #34758, skipping"
 # RUN curl -L https://patch-diff.githubusercontent.com/raw/vllm-project/vllm/pull/34302.diff | patch -p1 -R || echo "Cannot revert PR #34302, skipping"
 
+# setuptools_scm derives the wheel version from the nearest git tag. Fork branches often
+# carry tags that are not valid PEP 440 -- e.g. a respin suffixed "...-20260727d" yields the
+# candidate version "20260727d" -- which fails the build before anything compiles. Set this to
+# build independently of how the upstream branch happens to be tagged. Empty (the default) is
+# a no-op, so stock builds are unaffected.
+ARG SETUPTOOLS_SCM_PRETEND_VERSION=
+
 # Final Compilation
 RUN --mount=type=cache,id=ccache,target=/root/.ccache \
     --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
     --mount=type=cache,id=cargo-registry,target=/opt/cargo/registry \
     --mount=type=cache,id=cargo-git,target=/opt/cargo/git \
     --mount=type=cache,id=vllm-rust-target,target=/workspace/vllm/vllm/target \
-    VLLM_REQUIRE_RUST_FRONTEND=1 CARGO_BUILD_JOBS=${MAX_JOBS} \
+    env VLLM_REQUIRE_RUST_FRONTEND=1 CARGO_BUILD_JOBS=${MAX_JOBS} \
+    ${SETUPTOOLS_SCM_PRETEND_VERSION:+SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION} \
     uv build --no-build-isolation --wheel . --out-dir=/workspace/wheels -v
 
 # Dump git refs in the wheels dir.

--- a/build-and-copy.sh
+++ b/build-and-copy.sh
@@ -18,6 +18,10 @@ COPY_TO_FLAG=false
 SSH_USER="$USER"
 NO_BUILD=false
 VLLM_REF="main"
+# Build from a fork instead of upstream, e.g. an unmerged hardware-enablement branch.
+VLLM_REPO="https://github.com/vllm-project/vllm.git"
+# Optional: pin the wheel version when the ref's nearest tag is not valid PEP 440.
+SETUPTOOLS_SCM_PRETEND_VERSION=""
 VLLM_REF_SET=false
 FLASHINFER_REF="main"
 FLASHINFER_REF_SET=false
@@ -399,6 +403,9 @@ usage() {
     echo "  --force-vllm-download         : Force download of vLLM wheels (skip cached wheel checks)"
     echo "  --force-download              : Force download of all prebuilt wheels (skip cached wheel checks)"
     echo "  --vllm-ref <ref>              : vLLM commit SHA, branch or tag (default: 'main')"
+    echo "  --vllm-repo <url>             : vLLM git remote (default: upstream vllm-project/vllm)"
+    echo "  --scm-version <ver>           : SETUPTOOLS_SCM_PRETEND_VERSION; use when the ref's"
+    echo "                                  nearest tag is not valid PEP 440"
     echo "  --flashinfer-ref <ref>        : FlashInfer commit SHA, branch or tag (default: 'main')"
     echo "  -c, --copy-to <hosts>         : Host(s) to copy image to. Accepts comma or space-delimited lists; matching remote image IDs are skipped."
     echo "      --copy-to-host            : Alias for --copy-to (backwards compatibility)."
@@ -436,6 +443,8 @@ while [[ "$#" -gt 0 ]]; do
             FORCE_VLLM_DOWNLOAD=true
             ;;
         --vllm-ref) VLLM_REF="$2"; VLLM_REF_SET=true; shift ;;
+        --vllm-repo) VLLM_REPO="$2"; shift ;;
+        --scm-version) SETUPTOOLS_SCM_PRETEND_VERSION="$2"; shift ;;
         --flashinfer-ref) FLASHINFER_REF="$2"; FLASHINFER_REF_SET=true; shift ;;
         -c|--copy-to|--copy-to-host|--copy-to-hosts)
             COPY_TO_FLAG=true
@@ -797,7 +806,9 @@ if [ "$NO_BUILD" = false ]; then
                 "--target" "vllm-export"
                 "--output" "type=local,dest=./wheels"
                 "${COMMON_BUILD_FLAGS[@]}"
-                "--build-arg" "VLLM_REF=$VLLM_REF")
+                "--build-arg" "VLLM_REF=$VLLM_REF"
+                "--build-arg" "VLLM_REPO=$VLLM_REPO"
+                "--build-arg" "SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION")
 
             if [ "$APPLY_PRESET_VLLM_PRS" = true ]; then
                 echo "Applying preset vLLM PRs from the Dockerfile (explicitly requested)."


### PR DESCRIPTION
The vLLM remote was hardcoded to vllm-project/vllm, so the image could only be
built from upstream. Hardware-enablement work often lives on an unmerged fork
branch -- for example SM121/GB10 DeepSeek-V4 support in vllm-project/vllm#41834 --
and those users currently have to patch the Dockerfile.

Two additions, both defaulting to current behaviour so stock builds are unchanged:

1. ARG VLLM_REPO and --vllm-repo. The cache-hit path also repoints the remote with
   git remote set-url, otherwise a cached upstream clone would silently keep
   fetching from the wrong repository.

2. ARG SETUPTOOLS_SCM_PRETEND_VERSION and --scm-version. setuptools_scm derives the
   wheel version from the nearest git tag, and fork branches often carry tags that
   are not valid PEP 440 -- a respin suffixed "-20260727d" yields the candidate
   version "20260727d" and the build fails before compiling anything. Applied
   inline on the build step via :+ so an unset value is a true no-op.

Tested by building DeepSeek-V4-Flash-0731 from jasl/vllm@d64074e6 on 4x DGX Spark
(GB10/SM121); the resulting image serves and passes a correctness probe.