### PR TITLE
fix: broken speculative-config JSON in deepseek-v4-flash recipe

### DIFF
--- a/recipes/deepseek-v4-flash.yaml
+++ b/recipes/deepseek-v4-flash.yaml
@@ -28,6 +28,8 @@ defaults:
   max_num_seqs: 4
   max_num_batched_tokens: 8192
   num_speculative_tokens: 2
+  speculative_config: '{"method":"mtp","num_speculative_tokens":2}'
+  reasoning_config: '{"reasoning_parser":"deepseek_v4","reasoning_start_str":"","reasoning_end_str":""}'
 
 # Environment variables
 env:
@@ -49,13 +51,13 @@ command: |
       --max-num-batched-tokens {max_num_batched_tokens} \
       --gpu-memory-utilization {gpu_memory_utilization} \
       --enable-prefix-caching \
-      --speculative-config '{{"method":"mtp","num_speculative_tokens":{num_speculative_tokens}}}' \
+      --speculative-config '{speculative_config}' \
       --tokenizer-mode deepseek_v4 \
       --distributed-executor-backend ray \
       --tool-call-parser deepseek_v4 \
       --enable-auto-tool-choice \
       --reasoning-parser deepseek_v4 \
-      --reasoning-config '{{"reasoning_parser":"deepseek_v4","reasoning_start_str":"","reasoning_end_str":""}}' \
+      --reasoning-config '{reasoning_config}' \
       --default-chat-template-kwargs.thinking=true \
       --default-chat-template-kwargs.reasoning_effort=high \
       --load-format instanttensor


### PR DESCRIPTION
## Bug

The `deepseek-v4-flash` recipe (v1 format) produces invalid JSON for `--speculative-config`, causing vLLM to fail on launch:

```
vllm serve: error: argument --speculative-config/-sc: Value
{"method":"mtp","num_speculative_tokens":{num_speculative_tokens}}
cannot be converted to <function loads>.
```

## Root Cause

The v1 recipe escapes literal JSON braces as `{{` and `}}` to protect them from `{placeholder}` substitution. However, sparkrun's `arg_substitute` uses regex `\\{(.*?)\\}` (non-greedy), which matches from the first `{` in `{{` to the first `}`. With doubled braces, it consumes the entire JSON string — including the inner `{num_speculative_tokens}` placeholder — as one giant unmatched key. The placeholder is never substituted. The post-substitution `{{ → {` collapse then produces invalid JSON with a bare `{num_speculative_tokens}`.

## Fix

Move both JSON config values (`speculative_config` and `reasoning_config`) into the recipe's `defaults` dict as complete string values, then reference them as simple `{speculative_config}` and `{reasoning_config}` placeholders in the command template. This matches the pattern already used by v2 recipes (e.g. `deepseek4-flash-fp8-mtp-vllm`).