### PR TITLE
Fix V2 sampler gate to enforce thinking_token_budget

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -569,6 +569,16 @@ RUN python3 /tmp/vllm-patches/patch_vllm_routed_experts_weight_shape.py .
 # reservations behind just before vLLM sizes and allocates KV cache blocks.
 RUN python3 /tmp/vllm-patches/patch_vllm_spark_kv_cache_cleanup.py .
 
+# Sampler._requires_logits_processing (V2 GPU model runner) checks every
+# per-request sampling feature except thinking_token_budget, so a request that
+# sets only a thinking budget (with otherwise-default sampling params) skips
+# the whole logits-processing pipeline and the budget kernel never runs: the
+# model burns the full max_tokens on reasoning and returns content: null with
+# finish_reason "length". ThinkingBudgetState itself (add_request/apply/
+# apply_staged_writes) and ReasoningConfig's marker resolution are unaffected;
+# only this gate is missing the check. Not B12X-specific.
+RUN python3 /tmp/vllm-patches/patch_vllm_thinking_budget_gate.py .
+
 
 # Prepare build requirements
 RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv \

--- a/docker/patch_vllm_thinking_budget_gate.py
+++ b/docker/patch_vllm_thinking_budget_gate.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Fix the V2 GPU sampler's logits-processing gate to include thinking budgets.
+
+``Sampler._requires_logits_processing`` decides whether the per-step
+logits-processing pipeline (bias, penalties, bad words, thinking-token-budget,
+temperature, min_p, top_k/top_p) runs at all for the current batch. It checks
+every other per-request feature (logit bias, penalties, bad words, non-default
+temperature/min_p/top_k/top_p) but never checks
+``self.thinking_budget_state.use_thinking_budget``.
+
+``ThinkingBudgetState.add_request``/``apply_staged_writes``/``apply`` are all
+correctly wired into ``Sampler``, and ``ReasoningConfig`` correctly derives
+single-token ``<think>``/``</think>`` markers even when
+``--reasoning-config`` leaves ``reasoning_start_str``/``reasoning_end_str``
+empty (it falls back to the reasoning parser's own markers). None of that
+matters, though: a request that sets only ``thinking_token_budget`` with
+otherwise-default sampling params (e.g. ``temperature=0``, no penalties, no
+logit bias) makes ``_requires_logits_processing`` return ``False``, so
+``apply_sampling_params`` returns the raw logits immediately and the
+thinking-budget kernel never runs. The model then spends the full
+``max_tokens`` budget on reasoning, silently ignoring the budget and returning
+``content: null`` with ``finish_reason: "length"``.
+
+This is a serving-correctness bug, not a B12X-specific one, and it is not
+gated behind an opt-in flag: `_requires_logits_processing` is unconditionally
+wrong for any request that sets a thinking budget without also tripping one of
+the other checks.
+
+The patch is idempotent and fails on an unrecognized source shape instead of
+making a best-effort rewrite.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+TARGET_REL = Path("vllm/v1/worker/gpu/sample/sampler.py")
+
+
+class PatchError(RuntimeError):
+    pass
+
+
+def replace_once(text: str, old: str, new: str, description: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise PatchError(
+            f"expected one {description} source anchor, found {count}; "
+            "the vLLM source shape has changed"
+        )
+    return text.replace(old, new, 1)
+
+
+_GATE_MARKER = "self.thinking_budget_state.enabled and np.any("
+
+_ANCHOR = (
+    "        if np.any(self.bad_words_state.num_bad_words.np[idx_mapping_np] > 0):\n"
+    "            return True\n"
+    "\n"
+    "        states = self.sampling_states\n"
+)
+
+_REPLACEMENT = (
+    "        if np.any(self.bad_words_state.num_bad_words.np[idx_mapping_np] > 0):\n"
+    "            return True\n"
+    "        if self.thinking_budget_state.enabled and np.any(\n"
+    "            self.thinking_budget_state.use_thinking_budget[idx_mapping_np]\n"
+    "        ):\n"
+    "            return True\n"
+    "\n"
+    "        states = self.sampling_states\n"
+)
+
+
+def patch_sampler(text: str) -> str:
+    if _GATE_MARKER in text:
+        return text
+    return replace_once(
+        text, _ANCHOR, _REPLACEMENT, "_requires_logits_processing bad-words check"
+    )
+
+
+def main() -> int:
+    source_root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path.cwd()
+    target = source_root / TARGET_REL
+    if not target.exists():
+        print(f"{TARGET_REL} is absent; thinking-budget gate patch is not applicable")
+        return 0
+
+    original = target.read_text()
+    if "ThinkingBudgetState" not in original:
+        print(
+            f"{TARGET_REL} does not reference ThinkingBudgetState; "
+            "thinking-budget gate patch is not applicable"
+        )
+        return 0
+
+    updated = patch_sampler(original)
+    compile(updated, str(target), "exec")
+    if updated != original:
+        target.write_text(updated)
+        print(f"Applied thinking_token_budget logits-processing gate fix to {TARGET_REL}")
+    else:
+        print(
+            "thinking_token_budget logits-processing gate fix already present "
+            f"in {TARGET_REL}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except PatchError as exc:
+        raise SystemExit(f"thinking-budget gate patch failed: {exc}") from exc

--- a/tests/test_vllm_thinking_budget_gate_patch.py
+++ b/tests/test_vllm_thinking_budget_gate_patch.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+PROJECT_DIR = Path(__file__).resolve().parents[1]
+PATCHER_PATH = PROJECT_DIR / "docker/patch_vllm_thinking_budget_gate.py"
+SPEC = importlib.util.spec_from_file_location("thinking_budget_gate_patcher", PATCHER_PATH)
+assert SPEC is not None and SPEC.loader is not None
+PATCHER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(PATCHER)
+
+
+CURRENT_GATE = """    def _requires_logits_processing(self, idx_mapping_np: np.ndarray) -> bool:
+        if np.any(self.logit_bias_state.use_logit_bias[idx_mapping_np]):
+            return True
+        if np.any(self.penalties_state.use_penalty[idx_mapping_np]):
+            return True
+        if np.any(self.bad_words_state.num_bad_words.np[idx_mapping_np] > 0):
+            return True
+
+        states = self.sampling_states
+        temperatures = states.temperature.np[idx_mapping_np]
+        if np.any((temperatures != 0.0) & (temperatures != 1.0)):
+            return True
+        if np.any(states.min_p.np[idx_mapping_np] != 0.0):
+            return True
+        if np.any(states.top_k.np[idx_mapping_np] != states.vocab_size):
+            return True
+        return bool(np.any(states.top_p.np[idx_mapping_np] != 1.0))
+"""
+
+
+class ThinkingBudgetGatePatchTests(unittest.TestCase):
+    def test_gate_check_is_added_and_idempotent(self):
+        patched = PATCHER.patch_sampler(CURRENT_GATE)
+
+        self.assertIn("self.thinking_budget_state.enabled and np.any(", patched)
+        self.assertIn(
+            "self.thinking_budget_state.use_thinking_budget[idx_mapping_np]",
+            patched,
+        )
+        # The other checks and their order are preserved.
+        self.assertIn("if np.any(self.logit_bias_state.use_logit_bias", patched)
+        self.assertIn("states = self.sampling_states", patched)
+        self.assertLess(
+            patched.index("bad_words_state.num_bad_words"),
+            patched.index("thinking_budget_state.enabled"),
+        )
+        self.assertLess(
+            patched.index("thinking_budget_state.enabled"),
+            patched.index("states = self.sampling_states"),
+        )
+
+        self.assertEqual(PATCHER.patch_sampler(patched), patched)
+
+    def test_unknown_source_shape_fails(self):
+        with self.assertRaises(PATCHER.PatchError):
+            PATCHER.patch_sampler("class Sampler:\n    pass\n")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`thinking_token_budget` is supposed to cap how many tokens a reasoning model spends "thinking" before it has to give a real answer. On the V2 GPU model runner, it silently doesn't work: if a request sets a thinking budget but doesn't also set some other special sampling option (custom temperature, penalties, etc.), the sampler skips the code path that would enforce the cap. The model then keeps reasoning until it runs out of `max_tokens` and returns an empty answer.

This isn't specific to any one model or recipe — it affects any request that relies on `thinking_token_budget` under the V2 model runner with otherwise-default sampling settings (e.g. `temperature=0`, which is common for tool calls and deterministic answers).

## Symptom

A `deepseek_v4` request with `thinking_token_budget=64, max_tokens=128, temperature=0` burns all 128 tokens on reasoning and comes back with `content: null, finish_reason: "length"`. In production this showed up as broken tool calls and missed long-context answers — same root cause, just triggered by reasoning running long in both cases.

## Fix

One missing check in `Sampler._requires_logits_processing`
(`vllm/v1/worker/gpu/sample/sampler.py`):

```python
if self.thinking_budget_state.enabled and np.any(
    self.thinking_budget_state.use_thinking_budget[idx_mapping_np]
):
    return True
```

Everything else needed to make budgets work (`ThinkingBudgetState.add_request` / `apply_staged_writes` / `apply`, and `ReasoningConfig`'s fallback to the parser's own `<think>`/`</think>` markers) was already correct — this one gate check was the only thing missing.

Shipped as `docker/patch_vllm_thinking_budget_gate.py`, matching the existing `patch_vllm_*.py` convention (idempotent, no-ops on builds without this V2 sampler code).

## Testing

Unit tests (`tests/test_vllm_thinking_budget_gate_patch.py`) plus on-hardware validation: restarted a live 2x DGX Spark production server on the patched image and re-ran the same checks that had just failed on the unpatched one.

| Check | Unpatched | Patched |
|---|---|---|
| `thinking_token_budget=64` probe | `content: null`, `finish_reason: length` | `content: "Dawn"` (correct), `finish_reason: stop` |
| tool-call gate | `finish_reason: length`, invalid args | `finish_reason: tool_calls`, valid args |
| long-context needle @ 32K / 64K / 256K | MISS / MISS / MISS | HIT / HIT / HIT |
| decode throughput (512 tok, median of 3) | 376ms TTFT / 38.3 tok/s | 349ms TTFT / 39.3 tok/s (no regression) |
