### PR TITLE
Add 4x spark recipe for Qwen3.8-Flash-Next

### DIFF
--- a/mods/install-ray/run.sh
+++ b/mods/install-ray/run.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Install Ray into the container so vLLM can use the Ray distributed executor.
+#
+# The upstream qwen38-flash-next image (vllm/vllm-openai:qwen38-flash-next)
+# ships WITHOUT Ray, but launch-cluster.sh's --ray path runs `ray start --head`
+# / `ray start --address=...` inside each container and vLLM needs
+# --distributed-executor-backend ray. This mod adds the `ray` package to the
+# container's site-packages before those run (launch-cluster applies mods at
+# container start, ahead of start_ray_head/start_ray_worker and the vLLM launch
+# script).
+#
+# Note: this does NOT change NCCL transport selection. If the multi-node hang
+# is on the RoCE fabric (NCCL_IB_DISABLE=0 + HCA in get_env_flags), Ray alone
+# will not fix it -- pin NCCL to Ethernet (NCCL_IB_DISABLE=1) instead, see the
+# qwen recipe's env: notes.
+set -euo pipefail
+
+echo "[install-ray] Installing ray into the container..."
+if python3 -c "import ray" 2>/dev/null; then
+    echo "[install-ray] ray already present: $(python3 -c 'import ray; print(ray.__version__)')"
+else
+    pip install --no-cache-dir ray
+fi
+
+python3 -c "import ray; print('[install-ray] ray', ray.__version__, 'imports OK')"

--- a/recipes/4x-spark-cluster/qwen3.8-flash-next.yaml
+++ b/recipes/4x-spark-cluster/qwen3.8-flash-next.yaml
@@ -1,0 +1,44 @@
+# Recipe: Qwen/Qwen3.8-Flash-Next (full BF16 weights) on 4x DGX Spark
+
+recipe_version: "1"
+name: Qwen3.8-Flash-Next-BF16
+description: vLLM serving Qwen3.8-Flash-Next full BF16 weights on quad DGX Spark TP=4 with built-in MTP speculative decoding
+
+model: Qwen/Qwen3.8-Flash-Next
+
+# Container image to use. Qwen4-Exp (qwen4_exp) is not yet in vLLM main.
+container: vllm/vllm-openai:qwen38-flash-next
+pull_image: true
+
+# ~335 GiB BF16 requires a 4-node cluster at TP=4
+cluster_only: true
+
+# The upstream qwen38-flash-next image ships without Ray.
+mods:
+  - mods/install-ray
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 4
+  gpu_memory_utilization: 0.85
+  max_model_len: 262144
+  max_num_seqs: 256
+  # Tuned to 3 tokens
+  num_speculative_tokens: 3
+
+command: |
+  vllm serve Qwen/Qwen3.8-Flash-Next \
+    --host {host} \
+    --port {port} \
+    --tensor-parallel-size {tensor_parallel} \
+    --max-model-len {max_model_len} \
+    --max-num-seqs {max_num_seqs} \
+    --gpu-memory-utilization {gpu_memory_utilization} \
+    --enable-prefix-caching \
+    --enforce-eager \
+    --no-enable-flashinfer-autotune \
+    --speculative-config '{{"method":"mtp","num_speculative_tokens":{num_speculative_tokens}}}' \
+    --reasoning-parser qwen3 \
+    --tool-call-parser qwen3_coder \
+    --enable-auto-tool-choice


### PR DESCRIPTION
Only one mod needed for this one (the install ray patch).

This is the exact same patch as in #367, so I'll just rebase depending on which (if any) is merged first.

I get ~40 tok / s with this, pretty consistently. Full multimodal support, but somewhat lacking in sm120 support.
