### PR TITLE
build-and-copy.sh: --vllm-source-dir no longer disables B12x

### DIFF
--- a/build-and-copy.sh
+++ b/build-and-copy.sh
@@ -32,11 +32,13 @@ VLLM_SOURCE_DIR_SET=false
 VLLM_SOURCE_COMMIT=""
 VLLM_SOURCE_STAGING_DIR=""
 VLLM_SOURCE_CONTEXT=""
+WITH_B12X=false
 EXP_B12X=false
 EXP_B12X_VLLM_REPO="https://github.com/local-inference-lab/vllm"
 EXP_B12X_VLLM_REF="dev/infernal-invocation"
 B12X_PACKAGE_REPO="https://github.com/lukealonso/b12x.git"
-B12X_PACKAGE_REF="master"
+# 2026-08-31: needed to match latest local-inference-lab/vllm
+B12X_PACKAGE_REF="1.2.6"
 EXP_B12X_TORCH_VERSION="2.13.0"
 EXP_B12X_TORCHVISION_VERSION="0.28.0"
 EXP_B12X_TORCHAUDIO_VERSION="2.11.0"
@@ -169,6 +171,24 @@ gpu_arch_to_nccl_gencode() {
     echo "-gencode=arch=compute_${sm},code=sm_${sm}"
 }
 
+# Compare Git URLs by host and path so https, ssh, and git@ spellings of the
+# same repository match: https://github.com/vllm-project/vllm.git and
+# git@github.com:vllm-project/vllm both normalise to github.com/vllm-project/vllm.
+normalize_git_url() {
+    local url="$1"
+
+    url="${url%/}"
+    url="${url%.git}"
+    url="${url#ssh://}"
+    url="${url#git+ssh://}"
+    url="${url#https://}"
+    url="${url#http://}"
+    url="${url#git://}"
+    url="${url#git@}"
+    url="${url/://}"
+    printf '%s' "$url" | tr '[:upper:]' '[:lower:]'
+}
+
 prepare_local_vllm_source() {
     local requested_dir="$1"
     local source_dir
@@ -239,6 +259,9 @@ prepare_local_vllm_source() {
 
     VLLM_SOURCE_COMMIT="$resolved_commit"
     VLLM_SOURCE_CONTEXT="$VLLM_SOURCE_STAGING_DIR/vllm"
+    # VLLM_REPO becomes a sentinel below, which erases the upstream identity that
+    # B12X eligibility keys on. Remember where the checkout came from instead.
+    VLLM_SOURCE_ORIGIN_URL=$(git -C "$source_dir" remote get-url origin 2>/dev/null || true)
     VLLM_REPO="local-source"
     echo "Using clean local vLLM source at commit $VLLM_SOURCE_COMMIT."
 }
@@ -621,6 +644,7 @@ usage() {
     echo "  --tf5                         : Deprecated compatibility flag; tag defaults to 'vllm-node-tf5' (aliases: --pre-tf, --pre-transformers)"
     echo "  --exp-mxfp4, --experimental-mxfp4 : Build with experimental native MXFP4 support"
     echo "  --exp-b12x, --experimental-b12x   : Select B12X; pulls its prebuilt image unless a local wheel/image build is requested"
+    echo "  --with-b12x                   : Install the B12X kernel package even when the vLLM source is not recognised as upstream or the B12X fork"
     echo "  --apply-vllm-pr <pr-num>      : Apply a specific PR patch to vLLM source. Can be specified multiple times."
     echo "  --apply-preset-vllm-prs       : Apply preset vLLM PRs even with --vllm-repo, --vllm-ref, or --apply-vllm-pr."
     echo "  --apply-flashinfer-pr <pr-num>: Apply a specific PR patch to FlashInfer source. Can be specified multiple times."
@@ -716,6 +740,7 @@ while [[ "$#" -gt 0 ]]; do
         --tf5|--pre-tf|--pre-transformers) PRE_TRANSFORMERS=true ;;
         --exp-mxfp4|--experimental-mxfp4) EXP_MXFP4=true ;;
         --exp-b12x|--experimental-b12x) EXP_B12X=true ;;
+        --with-b12x) WITH_B12X=true ;;
         --apply-vllm-pr)
             if [ -n "$2" ] && [[ "$2" != -* ]]; then
                if [ -n "$VLLM_PRS" ]; then
@@ -830,21 +855,61 @@ if [ "$VLLM_REPO" != "$DEFAULT_VLLM_REPO" ] || [ "$VLLM_SOURCE_DIR_SET" = true ]
     CUSTOM_VLLM_REPO=true
 fi
 
-NORMALIZED_VLLM_REPO="${VLLM_REPO%/}"
-NORMALIZED_VLLM_REPO="${NORMALIZED_VLLM_REPO%.git}"
-NORMALIZED_DEFAULT_VLLM_REPO="${DEFAULT_VLLM_REPO%/}"
-NORMALIZED_DEFAULT_VLLM_REPO="${NORMALIZED_DEFAULT_VLLM_REPO%.git}"
-if [ "$NORMALIZED_VLLM_REPO" = "$NORMALIZED_DEFAULT_VLLM_REPO" ] || \
-   [ "$NORMALIZED_VLLM_REPO" = "$EXP_B12X_VLLM_REPO" ]; then
+# B12X kernels ship as an external package that both upstream vLLM and the
+# local-inference-lab fork load at runtime, so the wheel source decides whether
+# it is worth installing. --vllm-source-dir replaces VLLM_REPO with a sentinel,
+# which used to fail this check silently and produce an image whose B12X linear
+# and MoE backends abort at startup; fall back to the checkout's origin remote.
+NORMALIZED_VLLM_REPO=$(normalize_git_url "$VLLM_REPO")
+NORMALIZED_DEFAULT_VLLM_REPO=$(normalize_git_url "$DEFAULT_VLLM_REPO")
+NORMALIZED_B12X_VLLM_REPO=$(normalize_git_url "$EXP_B12X_VLLM_REPO")
+NORMALIZED_SOURCE_ORIGIN=$(normalize_git_url "$VLLM_SOURCE_ORIGIN_URL")
+
+# Normalised forms are for comparison only. Messages keep the URL as configured,
+# minus the trailing-slash and .git noise.
+B12X_DISPLAY_REPO="${VLLM_REPO%/}"
+B12X_DISPLAY_REPO="${B12X_DISPLAY_REPO%.git}"
+B12X_DISPLAY_ORIGIN="${VLLM_SOURCE_ORIGIN_URL%/}"
+B12X_DISPLAY_ORIGIN="${B12X_DISPLAY_ORIGIN%.git}"
+
+repo_supports_b12x() {
+    local candidate="$1"
+    [ -n "$candidate" ] || return 1
+    [ "$candidate" = "$NORMALIZED_DEFAULT_VLLM_REPO" ] || [ "$candidate" = "$NORMALIZED_B12X_VLLM_REPO" ]
+}
+
+B12X_ELIGIBLE=false
+B12X_SOURCE_LABEL="$B12X_DISPLAY_REPO"
+if repo_supports_b12x "$NORMALIZED_VLLM_REPO"; then
+    B12X_ELIGIBLE=true
+elif [ "$VLLM_SOURCE_DIR_SET" = true ] && repo_supports_b12x "$NORMALIZED_SOURCE_ORIGIN"; then
+    B12X_ELIGIBLE=true
+    B12X_SOURCE_LABEL="local source of ${B12X_DISPLAY_ORIGIN}"
+elif [ "$WITH_B12X" = true ]; then
+    B12X_ELIGIBLE=true
+    B12X_SOURCE_LABEL="${B12X_SOURCE_LABEL} (--with-b12x)"
+fi
+
+if [ "$B12X_ELIGIBLE" = true ]; then
     B12X_REPO="$B12X_PACKAGE_REPO"
     B12X_REF="$B12X_PACKAGE_REF"
     B12X_CACHEBUST="$(date +%s)"
     TORCH_BASE_VERSION="${TORCH_VERSION%%+*}"
     if [ "$(printf '%s\n' "2.12.0" "$TORCH_BASE_VERSION" | sort -V | head -n1)" != "2.12.0" ]; then
-        echo "Error: ${NORMALIZED_VLLM_REPO} requires --torch-version 2.12.0 or newer for B12X (got ${TORCH_VERSION})."
+        echo "Error: ${B12X_SOURCE_LABEL} requires --torch-version 2.12.0 or newer for B12X (got ${TORCH_VERSION})."
         exit 1
     fi
-    echo "Building B12X from ${B12X_REPO} ref ${B12X_REF} for ${NORMALIZED_VLLM_REPO} ref ${VLLM_REF}."
+    echo "Building B12X from ${B12X_REPO} ref ${B12X_REF} for ${B12X_SOURCE_LABEL} ref ${VLLM_REF}."
+elif [ "$VLLM_SOURCE_DIR_SET" = true ]; then
+    # Never leave this decision implicit: the failure otherwise only surfaces as a
+    # missing-kernel ValueError once a model is served.
+    if [ -n "$NORMALIZED_SOURCE_ORIGIN" ]; then
+        echo "Warning: The local vLLM checkout's origin (${B12X_DISPLAY_ORIGIN}) is not upstream vLLM or the B12X fork."
+    else
+        echo "Warning: The local vLLM checkout has no origin remote to identify it by."
+    fi
+    echo "         B12X kernels will NOT be installed, so --moe-backend b12x and --linear-backend b12x will fail at startup."
+    echo "         Re-run with --with-b12x to install the B12X kernel package anyway."
 fi
 
 # Source autodiscover.sh to load .env file

--- a/tests/test_build_and_copy.sh
+++ b/tests/test_build_and_copy.sh
@@ -210,6 +210,13 @@ assert_output_contains() {
     fi
 }
 
+assert_output_not_contains() {
+    local pattern="$1"
+    if grep -Eq "$pattern" "$OUTPUT_LOG"; then
+        fail "Expected output not to match: $pattern"
+    fi
+}
+
 test_default_uses_prebuilt() {
     setup_fixture
     run_build || fail "default run failed"
@@ -570,6 +577,72 @@ test_local_vllm_source_defaults_to_head() {
     assert_log_contains '^docker build --target vllm-export .*--build-arg VLLM_REF='"$LOCAL_VLLM_SOURCE_COMMIT"' --build-arg VLLM_REPO=local-source '
     assert_log_contains 'VLLM_SOURCE_COMMIT='"$LOCAL_VLLM_SOURCE_COMMIT"
     pass "--vllm-source-dir defaults to the checkout HEAD"
+}
+
+test_local_vllm_source_installs_b12x_for_upstream_origin() {
+    setup_fixture
+    create_local_vllm_source
+    git -C "$LOCAL_VLLM_SOURCE_DIR" remote add origin https://github.com/vllm-project/vllm.git
+    run_build --vllm-source-dir "$LOCAL_VLLM_SOURCE_DIR" || \
+        fail "--vllm-source-dir upstream-origin run failed"
+    assert_log_contains '^docker build -t vllm-node .*--build-arg B12X_REPO=https://github\.com/lukealonso/b12x\.git'
+    assert_output_contains 'Building B12X from .* for local source of https://github\.com/vllm-project/vllm ref '
+    pass "--vllm-source-dir installs B12X when the checkout tracks upstream vLLM"
+}
+
+test_local_vllm_source_installs_b12x_for_ssh_origin() {
+    setup_fixture
+    create_local_vllm_source
+    git -C "$LOCAL_VLLM_SOURCE_DIR" remote add origin git@github.com:vllm-project/vllm.git
+    run_build --vllm-source-dir "$LOCAL_VLLM_SOURCE_DIR" || \
+        fail "--vllm-source-dir ssh-origin run failed"
+    assert_log_contains 'B12X_REPO=https://github\.com/lukealonso/b12x\.git'
+    pass "B12X eligibility matches an ssh-spelled upstream origin"
+}
+
+test_local_vllm_source_installs_b12x_for_fork_origin() {
+    setup_fixture
+    create_local_vllm_source
+    git -C "$LOCAL_VLLM_SOURCE_DIR" remote add origin https://github.com/local-inference-lab/vllm
+    run_build --vllm-source-dir "$LOCAL_VLLM_SOURCE_DIR" || \
+        fail "--vllm-source-dir fork-origin run failed"
+    assert_log_contains 'B12X_REPO=https://github\.com/lukealonso/b12x\.git'
+    pass "B12X eligibility matches a local checkout of the B12X fork"
+}
+
+test_local_vllm_source_warns_when_b12x_is_skipped() {
+    setup_fixture
+    create_local_vllm_source
+    git -C "$LOCAL_VLLM_SOURCE_DIR" remote add origin https://github.com/someone/vllm-fork.git
+    run_build --vllm-source-dir "$LOCAL_VLLM_SOURCE_DIR" || \
+        fail "--vllm-source-dir unknown-origin run failed"
+    assert_log_not_contains 'B12X_REPO='
+    assert_output_contains "Warning: The local vLLM checkout's origin \\(https://github\\.com/someone/vllm-fork\\) is not upstream vLLM or the B12X fork\\."
+    assert_output_contains 'B12X kernels will NOT be installed'
+    assert_output_contains 'Re-run with --with-b12x'
+    pass "an unrecognised local checkout warns instead of silently dropping B12X"
+}
+
+test_local_vllm_source_warns_without_origin() {
+    setup_fixture
+    create_local_vllm_source
+    run_build --vllm-source-dir "$LOCAL_VLLM_SOURCE_DIR" || \
+        fail "--vllm-source-dir no-origin run failed"
+    assert_log_not_contains 'B12X_REPO='
+    assert_output_contains 'Warning: The local vLLM checkout has no origin remote to identify it by\.'
+    pass "a checkout without an origin warns instead of silently dropping B12X"
+}
+
+test_with_b12x_forces_the_kernel_package() {
+    setup_fixture
+    create_local_vllm_source
+    git -C "$LOCAL_VLLM_SOURCE_DIR" remote add origin https://github.com/someone/vllm-fork.git
+    run_build --vllm-source-dir "$LOCAL_VLLM_SOURCE_DIR" --with-b12x || \
+        fail "--with-b12x run failed"
+    assert_log_contains 'B12X_REPO=https://github\.com/lukealonso/b12x\.git'
+    assert_output_contains 'Building B12X from .* \(--with-b12x\) ref '
+    assert_output_not_contains 'B12X kernels will NOT be installed'
+    pass "--with-b12x installs the kernel package for an unrecognised source"
 }
 
 test_local_vllm_source_rejects_conflicting_repo() {
@@ -1300,6 +1373,12 @@ test_local_vllm_source_defaults_to_head
 test_local_vllm_source_rejects_conflicting_repo
 test_local_vllm_source_rejects_dirty_checkout
 test_local_vllm_source_rejects_missing_ref
+test_local_vllm_source_installs_b12x_for_upstream_origin
+test_local_vllm_source_installs_b12x_for_ssh_origin
+test_local_vllm_source_installs_b12x_for_fork_origin
+test_local_vllm_source_warns_when_b12x_is_skipped
+test_local_vllm_source_warns_without_origin
+test_with_b12x_forces_the_kernel_package
 test_exp_b12x_uses_prebuilt_image
 test_exp_b12x_rebuild_vllm_uses_preset_source_build
 test_exp_b12x_allows_vllm_prs


### PR DESCRIPTION
Fixes #363: A recent source checkout of vLLM 0.28.0+ (or https://github.com/local-inference-lab/vllm) won't complile all of the necessary B12X components for e.g. DS4F.

After investigating, vLLM 0.28.x doesn't (yet) have all of the local-inference-lab changes [from @lukealonso](https://github.com/vllm-project/vllm/issues?q=is%3Apr%20author%3Alukealonso) merged in for B12X, i.e. https://github.com/vllm-project/vllm/pull/52017, so the dual Spark DS4F recipe doesn't work.

[local-inference-lab](https://github.com/local-inference-lab/vllm) is very close to 0.28.x, including some fixes I wanted for DS4F stability, so I switched to building off that.  However, that tree was failing builds as well since there were some changes with upstream b12x packages.

# Changes

`build-and-copy.sh` changes:

* `--vllm-source-dir` no longer disables B12x
* Adds `--with-b12x` option to force B12x

# Fixes

`prepare_local_vllm_source()` sets `VLLM_REPO="local-source"`, which the B12X eligibility gate compares against two literal URLs - so a local clone of upstream vLLM never got the B12X kernel package, and `--linear-backend b12x` failed at runtime with `Failed to find a kernel that can implement the ScaledMM linear layer`.

The metadata recorded only `b12x_repo: "disabled"`.

The gate now falls back to the checkout's origin remote, compared via a new `normalize_git_url()` that matches `https`, `ssh`, and `git@` spellings. `--with-b12x` forces the package in for mirrors, forks, and checkouts without an origin. An unrecognised checkout now warns explicitly instead of failing silently at serve time.

# Results

This build command now works:

```sh
cd /opt

git clone https://github.com/eugr/spark-vllm-docker.git
git clone https://github.com/local-inference-lab/vllm.git

cd spark-vllm-docker

./build-and-copy.sh --rebuild-vllm --tag vllm-node:latest-b12x --vllm-source-dir /opt/vllm/
```

# AI Disclosure

This PR was investigated, codified and verified by an AI agent.  I have manually reviewed, verified and tweaked the output.